### PR TITLE
Add Agentic Legibility Score

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A curated, implementation-first list of **agent harness engineering** resources, with GitHub projects as the primary focus.
 
-- Total entries: **146**
-- GitHub entries: **122 (83.6%)**
-- GitHub in project categories (excluding readings): **118/118 (100.0%)**
+- Total entries: **147**
+- GitHub entries: **123 (83.7%)**
+- GitHub in project categories (excluding readings): **119/119 (100.0%)**
 - Categories: **9**
 - Last verified: **2026-04-13**
 - Language: [English](./README.md) | [中文](./README_zh.md)
@@ -45,7 +45,7 @@ A curated, implementation-first list of **agent harness engineering** resources,
 | Category | Entries |
 | --- | ---: |
 | Harness Architecture & Orchestration | 19 |
-| Context & Working-State Engineering | 8 |
+| Context & Working-State Engineering | 9 |
 | Execution Substrates & Sandboxing | 11 |
 | Protocols, Tool Interfaces & Agent Contracts | 11 |
 | Evaluation Harnesses & Benchmarks | 18 |
@@ -99,6 +99,7 @@ Notes:
 | Trellis | [GitHub](https://github.com/mindfold-ai/Trellis) | [![star](https://img.shields.io/badge/star-5150-f4b400?style=flat-square)](https://github.com/mindfold-ai/Trellis) | specs, memory, workflow | Multi-platform coding-agent workflow framework with task context, project memory, and spec injection. |
 | Awesome Context Engineering | [GitHub](https://github.com/Meirtz/Awesome-Context-Engineering) | [![star](https://img.shields.io/badge/star-3049-f4b400?style=flat-square)](https://github.com/Meirtz/Awesome-Context-Engineering) | awesome-list, context, survey | Survey-style list for context engineering resources and frameworks. |
 | context-space | [GitHub](https://github.com/context-space/context-space) | [![star](https://img.shields.io/badge/star-810-f4b400?style=flat-square)](https://github.com/context-space/context-space) | context, infrastructure, mcp | Infrastructure project focused on context engineering building blocks and MCP-centric integrations. |
+| Agentic Legibility Score | [GitHub](https://github.com/LatencyTDH/agentic-legibility) | [![star](https://img.shields.io/badge/star-3-f4b400?style=flat-square)](https://github.com/LatencyTDH/agentic-legibility) | repo-audit, readiness, coding-agent | Repository audit tool that scores setup, commands, docs, tests, and governance for coding-agent readiness. |
 
 <a id="execution-substrates-sandboxing"></a>
 ### Execution Substrates & Sandboxing

--- a/README_zh.md
+++ b/README_zh.md
@@ -2,9 +2,9 @@
 
 一个面向 **Agent Harness Engineering** 的工程实践清单，优先收录可直接落地的 GitHub 项目。
 
-- 当前条目数: **146**
-- GitHub 条目: **122 (83.6%)**
-- 项目分类 GitHub 占比（不含阅读类）: **118/118 (100.0%)**
+- 当前条目数: **147**
+- GitHub 条目: **123 (83.7%)**
+- 项目分类 GitHub 占比（不含阅读类）: **119/119 (100.0%)**
 - 分类数量: **9**
 - 最近核对日期: **2026-04-13**
 - 语言: [English](./README.md) | [中文](./README_zh.md)
@@ -45,7 +45,7 @@
 | 分类 | 条目数 |
 | --- | ---: |
 | Harness Architecture & Orchestration | 19 |
-| Context & Working-State Engineering | 8 |
+| Context & Working-State Engineering | 9 |
 | Execution Substrates & Sandboxing | 11 |
 | Protocols, Tool Interfaces & Agent Contracts | 11 |
 | Evaluation Harnesses & Benchmarks | 18 |
@@ -99,6 +99,7 @@
 | Trellis | [GitHub](https://github.com/mindfold-ai/Trellis) | [![star](https://img.shields.io/badge/star-5150-f4b400?style=flat-square)](https://github.com/mindfold-ai/Trellis) | specs, memory, workflow | 面向多平台编码代理的工作流框架，提供任务上下文、项目记忆与规范注入。 |
 | Awesome Context Engineering | [GitHub](https://github.com/Meirtz/Awesome-Context-Engineering) | [![star](https://img.shields.io/badge/star-3049-f4b400?style=flat-square)](https://github.com/Meirtz/Awesome-Context-Engineering) | awesome-list, context, survey | 面向上下文工程的综述型清单，覆盖资源与框架。 |
 | context-space | [GitHub](https://github.com/context-space/context-space) | [![star](https://img.shields.io/badge/star-810-f4b400?style=flat-square)](https://github.com/context-space/context-space) | context, infrastructure, mcp | 聚焦上下文工程基础设施的项目，强调 MCP 生态集成能力。 |
+| Agentic Legibility Score | [GitHub](https://github.com/LatencyTDH/agentic-legibility) | [![star](https://img.shields.io/badge/star-3-f4b400?style=flat-square)](https://github.com/LatencyTDH/agentic-legibility) | repo-audit, readiness, coding-agent | 评估仓库搭建、命令、文档、测试与治理等要素，以衡量 coding agent 就绪度的审计工具。 |
 
 <a id="execution-substrates-sandboxing"></a>
 ### Execution Substrates & Sandboxing

--- a/data/projects.yaml
+++ b/data/projects.yaml
@@ -395,6 +395,19 @@ entries:
   updated_at: '2025-10-22'
   license: AGPL-3.0
   why_included: Represents context infrastructure beyond prompt-level tricks.
+- name: Agentic Legibility Score
+  repo_url: https://github.com/LatencyTDH/agentic-legibility
+  category: Context & Working-State Engineering
+  summary_en: Repository audit tool that scores setup, commands, docs, tests, and governance for coding-agent readiness.
+  summary_zh: 评估仓库搭建、命令、文档、测试与治理等要素，以衡量 coding agent 就绪度的审计工具。
+  tags:
+  - repo-audit
+  - readiness
+  - coding-agent
+  stars_snapshot: 3
+  updated_at: '2026-04-14'
+  license: MIT
+  why_included: Helps teams spot missing repo-local scaffolding before asking coding agents to work autonomously.
 - name: Daytona
   repo_url: https://github.com/daytonaio/daytona
   category: Execution Substrates & Sandboxing

--- a/reports/verification/2026-04-14.md
+++ b/reports/verification/2026-04-14.md
@@ -1,0 +1,67 @@
+# Verification Report
+
+- Generated at: `2026-04-14T23:46:30.815515+00:00`
+- Total entries: `147`
+- GitHub entries: `123` (83.7%)
+- GitHub in project categories (excluding `Essential Readings & Ecosystem Maps`): `119/119` (100.0%)
+- Categories: `9`
+- URL checks: `148` total, `148` reachable, `0` broken
+
+## Category Counts
+
+| Category | Entries |
+| --- | ---: |
+| Harness Architecture & Orchestration | 19 |
+| Context & Working-State Engineering | 9 |
+| Execution Substrates & Sandboxing | 11 |
+| Protocols, Tool Interfaces & Agent Contracts | 11 |
+| Evaluation Harnesses & Benchmarks | 18 |
+| Observability & Reliability Operations | 13 |
+| Guardrails, Security & Governance | 11 |
+| Reference Harness Implementations | 27 |
+| Essential Readings & Ecosystem Maps | 28 |
+
+## Structural Errors
+
+- None
+
+## Warnings
+
+- None
+
+## Broken URLs
+
+- None
+
+## Reachable URL Sample
+
+- `HEAD 200` https://blog.langchain.com/agent-frameworks-runtimes-and-harnesses-oh-my/
+- `HEAD 200` https://blog.langchain.com/evaluating-deep-agents-our-learnings/
+- `HEAD 200` https://blog.langchain.com/improving-deep-agents-with-harness-engineering/
+- `HEAD 200` https://blog.langchain.com/the-anatomy-of-an-agent-harness/
+- `HEAD 200` https://claude.com/blog/building-agents-with-the-claude-agent-sdk
+- `HEAD 200` https://developers.openai.com/blog/eval-skills
+- `HEAD 200` https://github.com/AgentOps-AI/agentops
+- `HEAD 200` https://github.com/Aider-AI/aider
+- `HEAD 200` https://github.com/AndyMik90/Aperant
+- `HEAD 200` https://github.com/Arize-ai/openinference
+- `HEAD 200` https://github.com/Arize-ai/phoenix
+- `HEAD 200` https://github.com/BerriAI/litellm
+- `HEAD 200` https://github.com/DevAgentForge/Open-Claude-Cowork
+- `HEAD 200` https://github.com/EleutherAI/lm-evaluation-harness
+- `HEAD 200` https://github.com/FoundationAgents/OpenManus
+- `HEAD 200` https://github.com/GoogleCloudPlatform/scion
+- `HEAD 200` https://github.com/HKUDS/CLI-Anything
+- `HEAD 200` https://github.com/HKUDS/OpenHarness
+- `HEAD 200` https://github.com/Helicone/helicone
+- `HEAD 200` https://github.com/IBM/mcp
+- `HEAD 200` https://github.com/IBM/mcp-context-forge
+- `HEAD 200` https://github.com/Kong/kong
+- `HEAD 200` https://github.com/LatencyTDH/agentic-legibility
+- `HEAD 200` https://github.com/Meirtz/Awesome-Context-Engineering
+- `HEAD 200` https://github.com/MicrosoftDocs/mcp
+- `HEAD 200` https://github.com/NVIDIA-NeMo/Gym
+- `HEAD 200` https://github.com/NVIDIA/NeMo-Agent-Toolkit
+- `HEAD 200` https://github.com/OpenHands/OpenHands
+- `HEAD 200` https://github.com/OpenHands/benchmarks
+- `HEAD 200` https://github.com/OthmanAdi/planning-with-files


### PR DESCRIPTION
## Summary
- add **Agentic Legibility Score** under **Context & Working-State Engineering**
- update the rendered README files to keep the catalog in sync
- include a verification note with the submission

## Why it fits
Agentic Legibility Score evaluates the repo-local scaffolding that coding agents depend on: setup, commands, documentation, tests, and governance. That makes it a strong fit for a catalog focused on harnesses, context, and working-state quality rather than general-purpose agent frameworks.

## Validation
- rendered the catalog README files after the entry update
- ran the repo's verification flow before submitting
