### PR TITLE
feat: add TWZRD Agent Intel to Guardrails, Security & Governance

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ Notes:
 | Sponsio | [GitHub](https://github.com/SponsioLabs/Sponsio) | [![star](https://img.shields.io/badge/star-472-f4b400?style=flat-square)](https://github.com/SponsioLabs/Sponsio) | contracts, runtime-safety, guardrails | Runtime enforcement layer that checks every agent action against deterministic contracts before execution. |
 | DashClaw | [GitHub](https://github.com/ucsandman/DashClaw) | [![star](https://img.shields.io/badge/star-273-f4b400?style=flat-square)](https://github.com/ucsandman/DashClaw) | approvals, policy, audit | Governance layer that intercepts risky agent actions, enforces policy, routes approvals, and records audit-ready decision trails. |
 | Tandem | [GitHub](https://github.com/frumu-ai/tandem) | [![star](https://img.shields.io/badge/star-106-f4b400?style=flat-square)](https://github.com/frumu-ai/tandem) | runtime-authority, approvals, audit | Governed runtime authority layer for agents with scoped execution, tool visibility, permissioned memory, approval gates, and audit trails. |
+| TWZRD Agent Intel | [Website](https://intel.twzrd.xyz) | N/A | trust-scoring, pre-dispatch, on-chain-identity | On-chain AI agent trust scoring and pre-dispatch gating MCP server for Solana. Provides identity resolution, reputation scoring, pre-payment verification, and signed V5 x402 trust receipts. |
 
 <a id="reference-harness-implementations"></a>
 ### Reference Harness Implementations

--- a/data/projects.yaml
+++ b/data/projects.yaml
@@ -3725,3 +3725,16 @@ entries:
   updated_at: '2025-01-01'
   license: n/a
   why_included: High-signal practitioner framing for harness-first implementation.
+- name: TWZRD Agent Intel
+  repo_url: https://intel.twzrd.xyz
+  category: Guardrails, Security & Governance
+  summary_en: On-chain AI agent trust scoring and pre-dispatch gating MCP server for Solana. Provides identity resolution, reputation scoring, pre-payment verification, and signed V5 x402 trust receipts.
+  summary_zh: 基于 Solana 链上的 AI 代理信任评分与预调度门控 MCP 服务器，提供身份解析、信誉评分、预支付校验及签名 V5 x402 信任凭证。
+  tags:
+  - trust-scoring
+  - pre-dispatch
+  - on-chain-identity
+  stars_snapshot: 0
+  updated_at: '2026-06-06'
+  license: NOASSERTION
+  why_included: Provides on-chain agent trust verification as a guardrail before agents dispatch sub-tasks or payments to unknown peers — directly applicable to multi-agent Solana harness stacks.


### PR DESCRIPTION
Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) — MCP server for AI agent trust scoring and pre-dispatch verification on Solana.

In multi-agent systems, `score_agent` lets agents assess peer trustworthiness before delegating tasks. `preflight_check` gates actions based on on-chain trust state.

Zero-install: `{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}`

**Why Guardrails, Security & Governance**: TWZRD provides on-chain agent trust verification as a guardrail before agents dispatch sub-tasks or payments to unknown peers — directly applicable to multi-agent Solana harness stacks.

**Entry added to `data/projects.yaml` and `README.md`.**

Note: I was unable to run the render scripts locally, so the `README_zh.md` and verification report are not updated in this PR. Happy to run them if you can confirm the entry format looks correct.