### PR TITLE
Add BitRouter to Guardrails, Security & Governance

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A curated, implementation-first list of **agent harness engineering** resources, with GitHub projects as the primary focus.
 
-- Total entries: **268**
-- GitHub entries: **241 (89.9%)**
-- GitHub in project categories (excluding readings): **236/236 (100.0%)**
+- Total entries: **269**
+- GitHub entries: **242 (90.0%)**
+- GitHub in project categories (excluding readings): **237/237 (100.0%)**
 - Categories: **9**
 - Last verified: **2026-06-05**
 - Language: [English](./README.md) | [中文](./README_zh.md)
@@ -52,7 +52,7 @@ A curated, implementation-first list of **agent harness engineering** resources,
 | Protocols, Tool Interfaces & Agent Contracts | 23 |
 | Evaluation Harnesses & Benchmarks | 27 |
 | Observability & Reliability Operations | 14 |
-| Guardrails, Security & Governance | 19 |
+| Guardrails, Security & Governance | 20 |
 | Reference Harness Implementations | 68 |
 | Essential Readings & Ecosystem Maps | 32 |
 
@@ -271,6 +271,7 @@ Notes:
 | Haft | [GitHub](https://github.com/m0n0x41d/haft) | [![star](https://img.shields.io/badge/star-1337-f4b400?style=flat-square)](https://github.com/m0n0x41d/haft) | governance, decisions, mcp | Decision-governance harness that records falsifiable contracts, evidence, and commissions before agents execute. |
 | Sponsio | [GitHub](https://github.com/SponsioLabs/Sponsio) | [![star](https://img.shields.io/badge/star-472-f4b400?style=flat-square)](https://github.com/SponsioLabs/Sponsio) | contracts, runtime-safety, guardrails | Runtime enforcement layer that checks every agent action against deterministic contracts before execution. |
 | DashClaw | [GitHub](https://github.com/ucsandman/DashClaw) | [![star](https://img.shields.io/badge/star-273-f4b400?style=flat-square)](https://github.com/ucsandman/DashClaw) | approvals, policy, audit | Governance layer that intercepts risky agent actions, enforces policy, routes approvals, and records audit-ready decision trails. |
+| BitRouter | [GitHub](https://github.com/bitrouter/bitrouter) | [![star](https://img.shields.io/badge/star-166-f4b400?style=flat-square)](https://github.com/bitrouter/bitrouter) | gateway, proxy, routing | Agent-native LLM router that optimizes your agent with every run — zero harness changes, every model call reliable, traceable, secure, and cost-effective. Routes across OpenAI, Anthropic, Google, OpenRouter, Bedrock, and more through one local endpoint, with an MCP gateway, guardrails, and multi-account failover. |
 | Tandem | [GitHub](https://github.com/frumu-ai/tandem) | [![star](https://img.shields.io/badge/star-106-f4b400?style=flat-square)](https://github.com/frumu-ai/tandem) | runtime-authority, approvals, audit | Governed runtime authority layer for agents with scoped execution, tool visibility, permissioned memory, approval gates, and audit trails. |
 
 <a id="reference-harness-implementations"></a>

--- a/README_zh.md
+++ b/README_zh.md
@@ -2,9 +2,9 @@
 
 一个面向 **Agent Harness Engineering** 的工程实践清单，优先收录可直接落地的 GitHub 项目。
 
-- 当前条目数: **268**
-- GitHub 条目: **241 (89.9%)**
-- 项目分类 GitHub 占比（不含阅读类）: **236/236 (100.0%)**
+- 当前条目数: **269**
+- GitHub 条目: **242 (90.0%)**
+- 项目分类 GitHub 占比（不含阅读类）: **237/237 (100.0%)**
 - 分类数量: **9**
 - 最近核对日期: **2026-06-05**
 - 语言: [English](./README.md) | [中文](./README_zh.md)
@@ -52,7 +52,7 @@
 | Protocols, Tool Interfaces & Agent Contracts | 23 |
 | Evaluation Harnesses & Benchmarks | 27 |
 | Observability & Reliability Operations | 14 |
-| Guardrails, Security & Governance | 19 |
+| Guardrails, Security & Governance | 20 |
 | Reference Harness Implementations | 68 |
 | Essential Readings & Ecosystem Maps | 32 |
 
@@ -271,6 +271,7 @@
 | Haft | [GitHub](https://github.com/m0n0x41d/haft) | [![star](https://img.shields.io/badge/star-1337-f4b400?style=flat-square)](https://github.com/m0n0x41d/haft) | governance, decisions, mcp | 面向决策治理的 harness，在代理执行前沉淀可证伪契约、证据与 commission 生命周期。 |
 | Sponsio | [GitHub](https://github.com/SponsioLabs/Sponsio) | [![star](https://img.shields.io/badge/star-472-f4b400?style=flat-square)](https://github.com/SponsioLabs/Sponsio) | contracts, runtime-safety, guardrails | 运行时强制执行层，在代理动作执行前用确定性契约逐项检查。 |
 | DashClaw | [GitHub](https://github.com/ucsandman/DashClaw) | [![star](https://img.shields.io/badge/star-273-f4b400?style=flat-square)](https://github.com/ucsandman/DashClaw) | approvals, policy, audit | 面向代理的治理层，可拦截高风险动作、执行策略、路由审批，并记录可审计的决策轨迹。 |
+| BitRouter | [GitHub](https://github.com/bitrouter/bitrouter) | [![star](https://img.shields.io/badge/star-166-f4b400?style=flat-square)](https://github.com/bitrouter/bitrouter) | gateway, proxy, routing | 面向智能体的 LLM 路由器，每次运行都为你的智能体持续优化——无需改动 harness，让每一次模型调用都可靠、可追踪、安全且经济高效。通过单一本地端点路由到 OpenAI、Anthropic、Google、OpenRouter、Bedrock 等，内置 MCP 网关、护栏与多账号故障转移。 |
 | Tandem | [GitHub](https://github.com/frumu-ai/tandem) | [![star](https://img.shields.io/badge/star-106-f4b400?style=flat-square)](https://github.com/frumu-ai/tandem) | runtime-authority, approvals, audit | 面向代理的运行时权限治理层，提供作用域执行、工具可见性、权限化记忆、审批门禁与审计轨迹。 |
 
 <a id="reference-harness-implementations"></a>

--- a/data/projects.yaml
+++ b/data/projects.yaml
@@ -2257,6 +2257,19 @@ entries:
   updated_at: '2026-06-04'
   license: Apache-2.0
   why_included: Focuses specifically on gateway-layer controls for agents.
+- name: BitRouter
+  repo_url: https://github.com/bitrouter/bitrouter
+  category: Guardrails, Security & Governance
+  summary_en: Agent-native LLM router that optimizes your agent with every run — zero harness changes, every model call reliable, traceable, secure, and cost-effective. Routes across OpenAI, Anthropic, Google, OpenRouter, Bedrock, and more through one local endpoint, with an MCP gateway, guardrails, and multi-account failover.
+  summary_zh: 面向智能体的 LLM 路由器，每次运行都为你的智能体持续优化——无需改动 harness，让每一次模型调用都可靠、可追踪、安全且经济高效。通过单一本地端点路由到 OpenAI、Anthropic、Google、OpenRouter、Bedrock 等，内置 MCP 网关、护栏与多账号故障转移。
+  tags:
+  - gateway
+  - proxy
+  - routing
+  stars_snapshot: 166
+  updated_at: '2026-06-07'
+  license: Apache-2.0
+  why_included: Single local control point for cross-protocol model routing with guardrails and failover, built to sit inside agent harnesses.
 - name: ClawManager
   repo_url: https://github.com/Yuan-lab-LLM/ClawManager
   category: Guardrails, Security & Governance

--- a/reports/verification/2026-06-07.md
+++ b/reports/verification/2026-06-07.md
@@ -1,0 +1,67 @@
+# Verification Report
+
+- Generated at: `2026-06-07T20:13:31.812374+00:00`
+- Total entries: `269`
+- GitHub entries: `242` (90.0%)
+- GitHub in project categories (excluding `Essential Readings & Ecosystem Maps`): `237/237` (100.0%)
+- Categories: `9`
+- URL checks: `270` total, `270` reachable, `0` broken
+
+## Category Counts
+
+| Category | Entries |
+| --- | ---: |
+| Harness Architecture & Orchestration | 44 |
+| Context & Working-State Engineering | 16 |
+| Execution Substrates & Sandboxing | 25 |
+| Protocols, Tool Interfaces & Agent Contracts | 23 |
+| Evaluation Harnesses & Benchmarks | 27 |
+| Observability & Reliability Operations | 14 |
+| Guardrails, Security & Governance | 20 |
+| Reference Harness Implementations | 68 |
+| Essential Readings & Ecosystem Maps | 32 |
+
+## Structural Errors
+
+- None
+
+## Warnings
+
+- None
+
+## Broken URLs
+
+- None
+
+## Reachable URL Sample
+
+- `HEAD 200` https://blog.langchain.com/agent-frameworks-runtimes-and-harnesses-oh-my/
+- `HEAD 200` https://blog.langchain.com/evaluating-deep-agents-our-learnings/
+- `HEAD 200` https://blog.langchain.com/improving-deep-agents-with-harness-engineering/
+- `HEAD 200` https://blog.langchain.com/the-anatomy-of-an-agent-harness/
+- `HEAD 200` https://claude.com/blog/building-agents-with-the-claude-agent-sdk
+- `HEAD 200` https://cognition.ai/blog/what-we-learned-building-cloud-agents
+- `HEAD 200` https://developers.openai.com/blog/eval-skills
+- `HEAD 200` https://github.com/1jehuang/jcode
+- `HEAD 200` https://github.com/21st-dev/1code
+- `HEAD 200` https://github.com/2FastLabs/agent-squad
+- `HEAD 200` https://github.com/AVIDS2/memorix
+- `HEAD 200` https://github.com/AgentOps-AI/agentops
+- `HEAD 200` https://github.com/Aider-AI/aider
+- `HEAD 200` https://github.com/AndyMik90/Aperant
+- `HEAD 200` https://github.com/Arize-ai/openinference
+- `HEAD 200` https://github.com/Arize-ai/phoenix
+- `HEAD 200` https://github.com/Atmosphere/atmosphere
+- `HEAD 200` https://github.com/BerriAI/litellm
+- `HEAD 200` https://github.com/BloopAI/vibe-kanban
+- `HEAD 200` https://github.com/Chorus-AIDLC/Chorus
+- `HEAD 200` https://github.com/ChromeDevTools/chrome-devtools-mcp
+- `HEAD 200` https://github.com/ComposioHQ/agent-orchestrator
+- `HEAD 200` https://github.com/DevAgentForge/Open-Claude-Cowork
+- `HEAD 200` https://github.com/EleutherAI/lm-evaluation-harness
+- `HEAD 200` https://github.com/EveryInc/compound-engineering-plugin
+- `HEAD 200` https://github.com/FoundationAgents/OpenManus
+- `HEAD 200` https://github.com/Git-on-my-level/codex-autorunner
+- `HEAD 200` https://github.com/GoogleCloudPlatform/scion
+- `HEAD 200` https://github.com/HKUDS/CLI-Anything
+- `HEAD 200` https://github.com/HKUDS/OpenHarness


### PR DESCRIPTION
Adds BitRouter to Guardrails, Security & Governance — a direct peer to LiteLLM, Portkey Gateway, and AgentGateway already listed there. BitRouter is an open-source (Apache-2.0) agent-native LLM router that optimizes your agent with every run — zero harness changes, with every model call reliable, traceable, secure, and cost-effective — providing a single local control point with cross-protocol routing, an MCP gateway, guardrails, and multi-account failover.

- Edited `data/projects.yaml` only; regenerated `README.md` + `README_zh.md` via `scripts/render_readme.py`.
- `scripts/verify_catalog.py` passes (report committed).
- `stars_snapshot` set to the current GitHub count (166) and `updated_at` to today, rather than running a full `sync_github_metadata.py` (which would re-fetch every entry and bloat the diff). Happy to run the full sync if you'd prefer.

### Checklist
- [x] Link reachable
- [x] Category correct (peer to LiteLLM/Portkey/AgentGateway)
- [x] Summary concise and practical (EN + ZH)
- [x] Renders cleanly in both READMEs
- [x] Verification passes