### PR TITLE
Add Project Tiny Context Harness to context engineering catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A curated, implementation-first list of **agent harness engineering** resources, with GitHub projects as the primary focus.
 
-- Total entries: **288**
-- GitHub entries: **261 (90.6%)**
-- GitHub in project categories (excluding readings): **256/256 (100.0%)**
+- Total entries: **289**
+- GitHub entries: **262 (90.7%)**
+- GitHub in project categories (excluding readings): **257/257 (100.0%)**
 - Categories: **9**
 - Last verified: **2026-06-11**
 - Language: [English](./README.md) | [中文](./README_zh.md)
@@ -47,7 +47,7 @@ A curated, implementation-first list of **agent harness engineering** resources,
 | Category | Entries |
 | --- | ---: |
 | Harness Architecture & Orchestration | 48 |
-| Context & Working-State Engineering | 17 |
+| Context & Working-State Engineering | 18 |
 | Execution Substrates & Sandboxing | 25 |
 | Protocols, Tool Interfaces & Agent Contracts | 27 |
 | Evaluation Harnesses & Benchmarks | 27 |
@@ -139,6 +139,7 @@ Notes:
 | context-space | [GitHub](https://github.com/context-space/context-space) | [![star](https://img.shields.io/badge/star-810-f4b400?style=flat-square)](https://github.com/context-space/context-space) | context, infrastructure, mcp | Infrastructure project focused on context engineering building blocks and MCP-centric integrations. |
 | Memorix | [GitHub](https://github.com/AVIDS2/memorix) | [![star](https://img.shields.io/badge/star-512-f4b400?style=flat-square)](https://github.com/AVIDS2/memorix) | memory, mcp, cross-agent | Local-first cross-agent memory control plane with MCP support, workspace sync, sessions, and orchestration state. |
 | sd0x-dev-flow | [GitHub](https://github.com/sd0xdev/sd0x-dev-flow) | [![star](https://img.shields.io/badge/star-164-f4b400?style=flat-square)](https://github.com/sd0xdev/sd0x-dev-flow) | hooks, state-machine, claude-code | Claude Code harness layer with hook-enforced dual review, durable state-machine gates, context-compaction recovery, and fail-closed safety. |
+| Project Tiny Context Harness | [GitHub](https://github.com/Seven128/project-tiny-context-harness) | - | context, memory, coding-agents, validation | Minimal Context Harness package that installs repo-local project memory, AGENTS.md guidance, role Skills, and validation for fresh-agent recovery without SDLC phase ceremony. |
 
 <a id="execution-substrates-sandboxing"></a>
 ### Execution Substrates & Sandboxing

--- a/README_zh.md
+++ b/README_zh.md
@@ -2,9 +2,9 @@
 
 一个面向 **Agent Harness Engineering** 的工程实践清单，优先收录可直接落地的 GitHub 项目。
 
-- 当前条目数: **288**
-- GitHub 条目: **261 (90.6%)**
-- 项目分类 GitHub 占比（不含阅读类）: **256/256 (100.0%)**
+- 当前条目数: **289**
+- GitHub 条目: **262 (90.7%)**
+- 项目分类 GitHub 占比（不含阅读类）: **257/257 (100.0%)**
 - 分类数量: **9**
 - 最近核对日期: **2026-06-11**
 - 语言: [English](./README.md) | [中文](./README_zh.md)
@@ -47,7 +47,7 @@
 | 分类 | 条目数 |
 | --- | ---: |
 | Harness Architecture & Orchestration | 48 |
-| Context & Working-State Engineering | 17 |
+| Context & Working-State Engineering | 18 |
 | Execution Substrates & Sandboxing | 25 |
 | Protocols, Tool Interfaces & Agent Contracts | 27 |
 | Evaluation Harnesses & Benchmarks | 27 |
@@ -139,6 +139,7 @@
 | context-space | [GitHub](https://github.com/context-space/context-space) | [![star](https://img.shields.io/badge/star-810-f4b400?style=flat-square)](https://github.com/context-space/context-space) | context, infrastructure, mcp | 聚焦上下文工程基础设施的项目，强调 MCP 生态集成能力。 |
 | Memorix | [GitHub](https://github.com/AVIDS2/memorix) | [![star](https://img.shields.io/badge/star-512-f4b400?style=flat-square)](https://github.com/AVIDS2/memorix) | memory, mcp, cross-agent | 本地优先的跨代理记忆控制平面，支持 MCP、工作区同步、会话与编排状态。 |
 | sd0x-dev-flow | [GitHub](https://github.com/sd0xdev/sd0x-dev-flow) | [![star](https://img.shields.io/badge/star-164-f4b400?style=flat-square)](https://github.com/sd0xdev/sd0x-dev-flow) | hooks, state-machine, claude-code | Claude Code harness 层，提供钩子强制双重评审、持久状态机门禁、上下文压缩恢复与 fail-closed 安全机制。 |
+| Project Tiny Context Harness | [GitHub](https://github.com/Seven128/project-tiny-context-harness) | - | context, memory, coding-agents, validation | Minimal Context Harness 包，用于安装仓库本地项目记忆、AGENTS.md 指引、角色 Skills 与验证入口，帮助新的编码代理会话恢复项目事实，而不引入 SDLC 阶段仪式。 |
 
 <a id="execution-substrates-sandboxing"></a>
 ### Execution Substrates & Sandboxing

--- a/data/projects.yaml
+++ b/data/projects.yaml
@@ -957,6 +957,20 @@ entries:
   license: MIT
   why_included: README maps concrete code to harness sub-problems including state-machine gates, lifecycle interceptors, context
     recovery across compaction, tool gating, and review loops.
+- name: Project Tiny Context Harness
+  repo_url: https://github.com/Seven128/project-tiny-context-harness
+  category: Context & Working-State Engineering
+  summary_en: Minimal Context Harness package that installs repo-local project memory, AGENTS.md guidance, role Skills, and validation for fresh-agent recovery without SDLC phase ceremony.
+  summary_zh: Minimal Context Harness 包，用于安装仓库本地项目记忆、AGENTS.md 指引、角色 Skills 与验证入口，帮助新的编码代理会话恢复项目事实，而不引入 SDLC 阶段仪式。
+  tags:
+  - context
+  - memory
+  - coding-agents
+  - validation
+  stars_snapshot: 0
+  updated_at: '2026-06-10'
+  license: MIT
+  why_included: Helps fresh AI coding-agent sessions recover durable project intent, boundaries, ownership, and validation paths from repo-local files.
 - name: Daytona
   repo_url: https://github.com/daytonaio/daytona
   category: Execution Substrates & Sandboxing

--- a/reports/verification/2026-06-12.md
+++ b/reports/verification/2026-06-12.md
@@ -1,0 +1,36 @@
+# Verification Report
+
+- Generated at: `2026-06-11T20:56:54.815810+00:00`
+- Total entries: `289`
+- GitHub entries: `262` (90.7%)
+- GitHub in project categories (excluding `Essential Readings & Ecosystem Maps`): `257/257` (100.0%)
+- Categories: `9`
+- URL checks: `0` total, `0` reachable, `0` broken
+
+## Category Counts
+
+| Category | Entries |
+| --- | ---: |
+| Harness Architecture & Orchestration | 48 |
+| Context & Working-State Engineering | 18 |
+| Execution Substrates & Sandboxing | 25 |
+| Protocols, Tool Interfaces & Agent Contracts | 27 |
+| Evaluation Harnesses & Benchmarks | 27 |
+| Observability & Reliability Operations | 16 |
+| Guardrails, Security & Governance | 23 |
+| Reference Harness Implementations | 73 |
+| Essential Readings & Ecosystem Maps | 32 |
+
+## Structural Errors
+
+- None
+
+## Warnings
+
+- None
+
+## Broken URLs
+
+- None
+
+## Reachable URL Sample


### PR DESCRIPTION
Adds Project Tiny Context Harness to Context & Working-State Engineering.

It is a small MIT npm package for repo-local fresh-agent recovery: project context files, AGENTS.md guidance, role Skills, and validation checks. The entry is intentionally scoped to context recovery rather than claiming autonomous coding, benchmark wins, broad adoption, awards, or star growth.