### PR TITLE
Add agentmap to Context & Working-State Engineering

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A curated, implementation-first list of **agent harness engineering** resources, with GitHub projects as the primary focus.
 
-- Total entries: **307**
-- GitHub entries: **280 (91.2%)**
-- GitHub in project categories (excluding readings): **275/275 (100.0%)**
+- Total entries: **308**
+- GitHub entries: **281 (91.2%)**
+- GitHub in project categories (excluding readings): **276/276 (100.0%)**
 - Categories: **9**
 - Last verified: **2026-06-14**
 - Language: [English](./README.md) | [中文](./README_zh.md)
@@ -47,7 +47,7 @@ A curated, implementation-first list of **agent harness engineering** resources,
 | Category | Entries |
 | --- | ---: |
 | Harness Architecture & Orchestration | 50 |
-| Context & Working-State Engineering | 21 |
+| Context & Working-State Engineering | 22 |
 | Execution Substrates & Sandboxing | 27 |
 | Protocols, Tool Interfaces & Agent Contracts | 29 |
 | Evaluation Harnesses & Benchmarks | 29 |
@@ -145,6 +145,7 @@ Notes:
 | context-space | [GitHub](https://github.com/context-space/context-space) | [![star](https://img.shields.io/badge/star-810-f4b400?style=flat-square)](https://github.com/context-space/context-space) | context, infrastructure, mcp | Infrastructure project focused on context engineering building blocks and MCP-centric integrations. |
 | Memorix | [GitHub](https://github.com/AVIDS2/memorix) | [![star](https://img.shields.io/badge/star-521-f4b400?style=flat-square)](https://github.com/AVIDS2/memorix) | memory, mcp, cross-agent | Local-first cross-agent memory control plane with MCP support, workspace sync, sessions, and orchestration state. |
 | sd0x-dev-flow | [GitHub](https://github.com/sd0xdev/sd0x-dev-flow) | [![star](https://img.shields.io/badge/star-165-f4b400?style=flat-square)](https://github.com/sd0xdev/sd0x-dev-flow) | hooks, state-machine, claude-code | Claude Code harness layer with hook-enforced dual review, durable state-machine gates, context-compaction recovery, and fail-closed safety. |
+| agentmap | [GitHub](https://github.com/raymondchins/agentmap) | [![star](https://img.shields.io/badge/star-22-f4b400?style=flat-square)](https://github.com/raymondchins/agentmap) | repo-map, hooks, typescript | Queryable TS/JS import/symbol map with PageRank ranking, token-budgeted digests, --any router, post-commit refresh, and PreToolUse hook nudges for coding agents. |
 
 <a id="execution-substrates-sandboxing"></a>
 ### Execution Substrates & Sandboxing

--- a/README_zh.md
+++ b/README_zh.md
@@ -2,9 +2,9 @@
 
 一个面向 **Agent Harness Engineering** 的工程实践清单，优先收录可直接落地的 GitHub 项目。
 
-- 当前条目数: **307**
-- GitHub 条目: **280 (91.2%)**
-- 项目分类 GitHub 占比（不含阅读类）: **275/275 (100.0%)**
+- 当前条目数: **308**
+- GitHub 条目: **281 (91.2%)**
+- 项目分类 GitHub 占比（不含阅读类）: **276/276 (100.0%)**
 - 分类数量: **9**
 - 最近核对日期: **2026-06-14**
 - 语言: [English](./README.md) | [中文](./README_zh.md)
@@ -47,7 +47,7 @@
 | 分类 | 条目数 |
 | --- | ---: |
 | Harness Architecture & Orchestration | 50 |
-| Context & Working-State Engineering | 21 |
+| Context & Working-State Engineering | 22 |
 | Execution Substrates & Sandboxing | 27 |
 | Protocols, Tool Interfaces & Agent Contracts | 29 |
 | Evaluation Harnesses & Benchmarks | 29 |
@@ -145,6 +145,7 @@
 | context-space | [GitHub](https://github.com/context-space/context-space) | [![star](https://img.shields.io/badge/star-810-f4b400?style=flat-square)](https://github.com/context-space/context-space) | context, infrastructure, mcp | 聚焦上下文工程基础设施的项目，强调 MCP 生态集成能力。 |
 | Memorix | [GitHub](https://github.com/AVIDS2/memorix) | [![star](https://img.shields.io/badge/star-521-f4b400?style=flat-square)](https://github.com/AVIDS2/memorix) | memory, mcp, cross-agent | 本地优先的跨代理记忆控制平面，支持 MCP、工作区同步、会话与编排状态。 |
 | sd0x-dev-flow | [GitHub](https://github.com/sd0xdev/sd0x-dev-flow) | [![star](https://img.shields.io/badge/star-165-f4b400?style=flat-square)](https://github.com/sd0xdev/sd0x-dev-flow) | hooks, state-machine, claude-code | Claude Code harness 层，提供钩子强制双重评审、持久状态机门禁、上下文压缩恢复与 fail-closed 安全机制。 |
+| agentmap | [GitHub](https://github.com/raymondchins/agentmap) | [![star](https://img.shields.io/badge/star-22-f4b400?style=flat-square)](https://github.com/raymondchins/agentmap) | repo-map, hooks, typescript | 可查询的 TS/JS 导入/符号图谱，含 PageRank 排序、token 预算摘要、--any 路由、提交后自动刷新，以及面向编码代理的 PreToolUse 钩子引导。 |
 
 <a id="execution-substrates-sandboxing"></a>
 ### Execution Substrates & Sandboxing

--- a/data/projects.yaml
+++ b/data/projects.yaml
@@ -1046,6 +1046,22 @@ entries:
   license: MIT
   why_included: README maps concrete code to harness sub-problems including state-machine gates, lifecycle interceptors, context
     recovery across compaction, tool gating, and review loops.
+- name: agentmap
+  repo_url: https://github.com/raymondchins/agentmap
+  category: Context & Working-State Engineering
+  summary_en: Queryable TS/JS import/symbol map with PageRank ranking, token-budgeted digests, --any router, post-commit refresh,
+    and PreToolUse hook nudges for coding agents.
+  summary_zh: 可查询的 TS/JS 导入/符号图谱，含 PageRank 排序、token 预算摘要、--any 路由、提交后自动刷新，以及面向编码代理的 PreToolUse 钩子引导。
+  tags:
+  - repo-map
+  - hooks
+  - typescript
+  stars_snapshot: 22
+  updated_at: '2026-06-14'
+  license: MIT
+  why_included: README documents benchmarked context-token savings on real repos, hook-based agent-loop integration (post-commit
+    refresh and PreToolUse nudge), optional MCP exposure, and cross-agent setup for Claude Code, Cursor, and other coding agents;
+    scope is TS/JS import graphs rather than multi-language call graphs.
 - name: Daytona
   repo_url: https://github.com/daytonaio/daytona
   category: Execution Substrates & Sandboxing

--- a/reports/verification/2026-06-14.md
+++ b/reports/verification/2026-06-14.md
@@ -1,18 +1,18 @@
 # Verification Report
 
-- Generated at: `2026-06-14T06:37:03.062648+00:00`
-- Total entries: `307`
-- GitHub entries: `280` (91.2%)
-- GitHub in project categories (excluding `Essential Readings & Ecosystem Maps`): `275/275` (100.0%)
+- Generated at: `2026-06-14T15:56:03.822047+00:00`
+- Total entries: `308`
+- GitHub entries: `281` (91.2%)
+- GitHub in project categories (excluding `Essential Readings & Ecosystem Maps`): `276/276` (100.0%)
 - Categories: `9`
-- URL checks: `308` total, `308` reachable, `0` broken
+- URL checks: `309` total, `309` reachable, `0` broken
 
 ## Category Counts
 
 | Category | Entries |
 | --- | ---: |
 | Harness Architecture & Orchestration | 50 |
-| Context & Working-State Engineering | 21 |
+| Context & Working-State Engineering | 22 |
 | Execution Substrates & Sandboxing | 27 |
 | Protocols, Tool Interfaces & Agent Contracts | 29 |
 | Evaluation Harnesses & Benchmarks | 29 |


### PR DESCRIPTION
## Summary
- Adds [agentmap](https://github.com/raymondchins/agentmap) under **Context & Working-State Engineering**
- Queryable TS/JS import/symbol map with PageRank ranking, token-budgeted digests, `--any` router, post-commit refresh, and PreToolUse hook nudges for coding agents
- Complements existing entries like Graphify and CodeGraph with a lightweight, hook-integrated repo-map layer focused on agent-loop context efficiency

## Test plan
- [x] `python3 scripts/sync_github_metadata.py`
- [x] `python3 scripts/render_readme.py`
- [x] `python3 scripts/verify_catalog.py` (passed)


Made with [Cursor](https://cursor.com)