### PR TITLE
Add Agent AFK (Reference Harness Implementations)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A curated, implementation-first list of **agent harness engineering** resources, with GitHub projects as the primary focus.
 
-- Total entries: **320**
-- GitHub entries: **293 (91.6%)**
-- GitHub in project categories (excluding readings): **288/288 (100.0%)**
+- Total entries: **321**
+- GitHub entries: **294 (91.6%)**
+- GitHub in project categories (excluding readings): **289/289 (100.0%)**
 - Categories: **9**
 - Last verified: **2026-06-17**
 - Language: [English](./README.md) | [中文](./README_zh.md)
@@ -53,7 +53,7 @@ A curated, implementation-first list of **agent harness engineering** resources,
 | Evaluation Harnesses & Benchmarks | 29 |
 | Observability & Reliability Operations | 20 |
 | Guardrails, Security & Governance | 24 |
-| Reference Harness Implementations | 82 |
+| Reference Harness Implementations | 83 |
 | Essential Readings & Ecosystem Maps | 32 |
 
 ## Catalog
@@ -398,6 +398,7 @@ Notes:
 | Munder Difflin | [GitHub](https://github.com/chaitanyagiri/munder-difflin) | [![star](https://img.shields.io/badge/star-533-f4b400?style=flat-square)](https://github.com/chaitanyagiri/munder-difflin) | multi-agent, desktop, memory | Desktop multi-agent harness that wraps terminal-agent CLIs with hive mailboxes, shared memory, an orchestrator, approvals, worktrees, and telemetry. |
 | OpenClaw.NET | [GitHub](https://github.com/clawdotnet/openclaw.net) | [![star](https://img.shields.io/badge/star-392-f4b400?style=flat-square)](https://github.com/clawdotnet/openclaw.net) | dotnet, gateway, governance | NativeAOT-friendly .NET agent runtime and gateway with tools, memory, MCP, governance ledger, evidence bundles, and harness regression tests. |
 | Utah | [GitHub](https://github.com/inngest/utah) | [![star](https://img.shields.io/badge/star-118-f4b400?style=flat-square)](https://github.com/inngest/utah) | durable-execution, event-driven, multi-channel | Inngest-powered durable agent harness with a think-act-observe loop, step-level retries, singleton concurrency, cancellation, and multi-channel adapters. |
+| Agent AFK | [GitHub](https://github.com/griffinwork40/agent-afk) | [![star](https://img.shields.io/badge/star-16-f4b400?style=flat-square)](https://github.com/griffinwork40/agent-afk) | coding-agent, away-from-keyboard, mcp | Four-surface coding-agent harness (CLI, REPL, cron daemon, Telegram bot) for unattended away-from-keyboard runs, with an editable loop, MCP client, lifecycle hooks, background sub-agents, cross-session memory, and a provider-agnostic event stream. |
 
 <a id="essential-readings-ecosystem-maps"></a>
 ### Essential Readings & Ecosystem Maps

--- a/README_zh.md
+++ b/README_zh.md
@@ -2,9 +2,9 @@
 
 一个面向 **Agent Harness Engineering** 的工程实践清单，优先收录可直接落地的 GitHub 项目。
 
-- 当前条目数: **320**
-- GitHub 条目: **293 (91.6%)**
-- 项目分类 GitHub 占比（不含阅读类）: **288/288 (100.0%)**
+- 当前条目数: **321**
+- GitHub 条目: **294 (91.6%)**
+- 项目分类 GitHub 占比（不含阅读类）: **289/289 (100.0%)**
 - 分类数量: **9**
 - 最近核对日期: **2026-06-17**
 - 语言: [English](./README.md) | [中文](./README_zh.md)
@@ -53,7 +53,7 @@
 | Evaluation Harnesses & Benchmarks | 29 |
 | Observability & Reliability Operations | 20 |
 | Guardrails, Security & Governance | 24 |
-| Reference Harness Implementations | 82 |
+| Reference Harness Implementations | 83 |
 | Essential Readings & Ecosystem Maps | 32 |
 
 ## 项目清单
@@ -398,6 +398,7 @@
 | Munder Difflin | [GitHub](https://github.com/chaitanyagiri/munder-difflin) | [![star](https://img.shields.io/badge/star-533-f4b400?style=flat-square)](https://github.com/chaitanyagiri/munder-difflin) | multi-agent, desktop, memory | 桌面多代理 harness，将终端代理 CLI 包装为带蜂巢邮箱、共享记忆、编排器、审批、worktree 与遥测的协作系统。 |
 | OpenClaw.NET | [GitHub](https://github.com/clawdotnet/openclaw.net) | [![star](https://img.shields.io/badge/star-392-f4b400?style=flat-square)](https://github.com/clawdotnet/openclaw.net) | dotnet, gateway, governance | NativeAOT 友好的 .NET 代理运行时与网关，提供工具、记忆、MCP、治理账本、证据包与 harness 回归测试。 |
 | Utah | [GitHub](https://github.com/inngest/utah) | [![star](https://img.shields.io/badge/star-118-f4b400?style=flat-square)](https://github.com/inngest/utah) | durable-execution, event-driven, multi-channel | 基于 Inngest 的持久代理 harness，提供思考-行动-观察循环、步骤级重试、单例并发、取消与多通道适配。 |
+| Agent AFK | [GitHub](https://github.com/griffinwork40/agent-afk) | [![star](https://img.shields.io/badge/star-16-f4b400?style=flat-square)](https://github.com/griffinwork40/agent-afk) | coding-agent, away-from-keyboard, mcp | 面向无人值守、离开键盘场景的四端编码代理 harness（CLI、REPL、定时守护进程、Telegram 机器人），具备可编辑循环、MCP 客户端、生命周期钩子、后台子代理、跨会话记忆，以及与模型无关的事件流。 |
 
 <a id="essential-readings-ecosystem-maps"></a>
 ### Essential Readings & Ecosystem Maps

--- a/data/projects.yaml
+++ b/data/projects.yaml
@@ -4501,3 +4501,16 @@ entries:
   updated_at: '2025-01-01'
   license: n/a
   why_included: High-signal practitioner framing for harness-first implementation.
+- name: Agent AFK
+  repo_url: https://github.com/griffinwork40/agent-afk
+  category: Reference Harness Implementations
+  summary_en: Four-surface coding-agent harness (CLI, REPL, cron daemon, Telegram bot) for unattended away-from-keyboard runs, with an editable loop, MCP client, lifecycle hooks, background sub-agents, cross-session memory, and a provider-agnostic event stream.
+  summary_zh: 面向无人值守、离开键盘场景的四端编码代理 harness（CLI、REPL、定时守护进程、Telegram 机器人），具备可编辑循环、MCP 客户端、生命周期钩子、后台子代理、跨会话记忆，以及与模型无关的事件流。
+  tags:
+  - coding-agent
+  - away-from-keyboard
+  - mcp
+  stars_snapshot: 16
+  updated_at: '2026-06-17'
+  license: Apache-2.0
+  why_included: README documents an editable agent loop (prompts, permission gates, model routing, explicit terminal states), four surfaces sharing one session manager, an MCP client, lifecycle hooks, background sub-agents, cross-session memory, and provider-agnostic routing across Anthropic and OpenAI-compatible backends including local runners.

--- a/reports/verification/2026-06-18.md
+++ b/reports/verification/2026-06-18.md
@@ -1,0 +1,67 @@
+# Verification Report
+
+- Generated at: `2026-06-18T11:05:40.084502+00:00`
+- Total entries: `321`
+- GitHub entries: `294` (91.6%)
+- GitHub in project categories (excluding `Essential Readings & Ecosystem Maps`): `289/289` (100.0%)
+- Categories: `9`
+- URL checks: `322` total, `322` reachable, `0` broken
+
+## Category Counts
+
+| Category | Entries |
+| --- | ---: |
+| Harness Architecture & Orchestration | 52 |
+| Context & Working-State Engineering | 24 |
+| Execution Substrates & Sandboxing | 27 |
+| Protocols, Tool Interfaces & Agent Contracts | 30 |
+| Evaluation Harnesses & Benchmarks | 29 |
+| Observability & Reliability Operations | 20 |
+| Guardrails, Security & Governance | 24 |
+| Reference Harness Implementations | 83 |
+| Essential Readings & Ecosystem Maps | 32 |
+
+## Structural Errors
+
+- None
+
+## Warnings
+
+- None
+
+## Broken URLs
+
+- None
+
+## Reachable URL Sample
+
+- `HEAD 200` https://blog.langchain.com/agent-frameworks-runtimes-and-harnesses-oh-my/
+- `HEAD 200` https://blog.langchain.com/evaluating-deep-agents-our-learnings/
+- `HEAD 200` https://blog.langchain.com/improving-deep-agents-with-harness-engineering/
+- `HEAD 200` https://blog.langchain.com/the-anatomy-of-an-agent-harness/
+- `HEAD 200` https://claude.com/blog/building-agents-with-the-claude-agent-sdk
+- `HEAD 200` https://cognition.ai/blog/what-we-learned-building-cloud-agents
+- `HEAD 200` https://developers.openai.com/blog/eval-skills
+- `HEAD 200` https://github.com/1jehuang/jcode
+- `HEAD 200` https://github.com/21st-dev/1code
+- `HEAD 200` https://github.com/2FastLabs/agent-squad
+- `HEAD 200` https://github.com/AVIDS2/memorix
+- `HEAD 200` https://github.com/AgentOps-AI/agentops
+- `HEAD 200` https://github.com/Agenta-AI/agenta
+- `HEAD 200` https://github.com/Aider-AI/aider
+- `HEAD 200` https://github.com/AndyMik90/Aperant
+- `HEAD 200` https://github.com/Arize-ai/openinference
+- `HEAD 200` https://github.com/Arize-ai/phoenix
+- `HEAD 200` https://github.com/Atmosphere/atmosphere
+- `HEAD 200` https://github.com/BerriAI/litellm
+- `HEAD 200` https://github.com/BloopAI/vibe-kanban
+- `HEAD 200` https://github.com/Chachamaru127/claude-code-harness
+- `HEAD 200` https://github.com/Chorus-AIDLC/Chorus
+- `HEAD 200` https://github.com/ChromeDevTools/chrome-devtools-mcp
+- `HEAD 200` https://github.com/ComposioHQ/agent-orchestrator
+- `HEAD 200` https://github.com/DevAgentForge/Open-Claude-Cowork
+- `HEAD 200` https://github.com/EleutherAI/lm-evaluation-harness
+- `HEAD 200` https://github.com/EverMind-AI/EverOS
+- `HEAD 200` https://github.com/EveryInc/compound-engineering-plugin
+- `HEAD 200` https://github.com/FoundationAgents/OpenManus
+- `HEAD 200` https://github.com/Gentleman-Programming/engram


### PR DESCRIPTION
Adds [**Agent AFK**](https://github.com/griffinwork40/agent-afk) (Apache-2.0, npm `agent-afk`) to **Reference Harness Implementations**.

Followed the data-driven contribution flow:
- Edited only `data/projects.yaml` (new entry with `summary_en` + `summary_zh`, tags, `stars_snapshot`, `updated_at`, license, `why_included`).
- Regenerated `README.md` + `README_zh.md` via `scripts/render_readme.py`.
- Ran `scripts/verify_catalog.py` → **Verification passed** (322/322 URLs reachable, READMEs in sync, schema/dup/staleness checks OK); committed `reports/verification/2026-06-18.md`.
- Did **not** run `sync_github_metadata.py` to avoid a large unrelated diff refreshing every entry's stars; supplied accurate snapshot manually (16★, updated 2026-06-17).

**Why it belongs:** an inspectable, end-to-end coding-agent harness whose loop is editable code — prompts, permission gates, model routing, explicit terminal states — across four surfaces (CLI, REPL, cron daemon, Telegram bot) sharing one session manager, with an MCP client, lifecycle hooks, background sub-agents, cross-session memory, and a provider-agnostic event stream (Anthropic + OpenAI-compatible, incl. local MLX/llama.cpp). Sits alongside Dexto and the other reference implementations.

**Checklist:** link reachable ✅ · category correct ✅ · concise summary ✅ · mirrors render cleanly ✅ · verification passes ✅