### PR TITLE
Add cc-sandbox-server (Execution Substrates & Sandboxing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A curated, implementation-first list of **agent harness engineering** resources, with GitHub projects as the primary focus.
 
-- Total entries: **338**
-- GitHub entries: **311 (92.0%)**
-- GitHub in project categories (excluding readings): **306/306 (100.0%)**
+- Total entries: **339**
+- GitHub entries: **312 (92.0%)**
+- GitHub in project categories (excluding readings): **307/307 (100.0%)**
 - Categories: **9**
 - Last verified: **2026-06-21**
 - Language: [English](./README.md) | [中文](./README_zh.md)
@@ -48,7 +48,7 @@ A curated, implementation-first list of **agent harness engineering** resources,
 | --- | ---: |
 | Harness Architecture & Orchestration | 57 |
 | Context & Working-State Engineering | 24 |
-| Execution Substrates & Sandboxing | 27 |
+| Execution Substrates & Sandboxing | 28 |
 | Protocols, Tool Interfaces & Agent Contracts | 41 |
 | Evaluation Harnesses & Benchmarks | 29 |
 | Observability & Reliability Operations | 20 |
@@ -188,6 +188,7 @@ Notes:
 | agentbox | [GitHub](https://github.com/mattolson/agent-sandbox) | [![star](https://img.shields.io/badge/star-185-f4b400?style=flat-square)](https://github.com/mattolson/agent-sandbox) | sandbox, coding-agents, network-policy | Locked-down local sandbox for AI coding agents with scoped filesystem access, egress policy, secret injection, firewalling, and persistent agent state. |
 | HexAgent | [GitHub](https://github.com/UnicomAI/hexagent) | [![star](https://img.shields.io/badge/star-124-f4b400?style=flat-square)](https://github.com/UnicomAI/hexagent) | computer-layer, sandbox, runtime | Agent harness that separates the runtime from the computer it operates on through local, VM, and cloud sandbox backends. |
 | terminal-bench-env | [GitHub](https://github.com/ucsb-mlsec/terminal-bench-env) | [![star](https://img.shields.io/badge/star-70-f4b400?style=flat-square)](https://github.com/ucsb-mlsec/terminal-bench-env) | terminal, benchmark-env, sandbox | Environment layer for terminal-agent benchmark execution. |
+| cc-sandbox-server | [GitHub](https://github.com/weijiafu14/cc-sandbox-server) | - | split-brain, sandbox, claude-code | Split-brain sandboxing for Claude Code-compatible runtimes — keeps the harness, session, and credentials on the host and forwards only tool execution into a disposable sandbox, with seamless crash recovery. |
 
 <a id="protocols-tool-interfaces-agent-contracts"></a>
 ### Protocols, Tool Interfaces & Agent Contracts

--- a/README_zh.md
+++ b/README_zh.md
@@ -2,9 +2,9 @@
 
 一个面向 **Agent Harness Engineering** 的工程实践清单，优先收录可直接落地的 GitHub 项目。
 
-- 当前条目数: **338**
-- GitHub 条目: **311 (92.0%)**
-- 项目分类 GitHub 占比（不含阅读类）: **306/306 (100.0%)**
+- 当前条目数: **339**
+- GitHub 条目: **312 (92.0%)**
+- 项目分类 GitHub 占比（不含阅读类）: **307/307 (100.0%)**
 - 分类数量: **9**
 - 最近核对日期: **2026-06-21**
 - 语言: [English](./README.md) | [中文](./README_zh.md)
@@ -48,7 +48,7 @@
 | --- | ---: |
 | Harness Architecture & Orchestration | 57 |
 | Context & Working-State Engineering | 24 |
-| Execution Substrates & Sandboxing | 27 |
+| Execution Substrates & Sandboxing | 28 |
 | Protocols, Tool Interfaces & Agent Contracts | 41 |
 | Evaluation Harnesses & Benchmarks | 29 |
 | Observability & Reliability Operations | 20 |
@@ -188,6 +188,7 @@
 | agentbox | [GitHub](https://github.com/mattolson/agent-sandbox) | [![star](https://img.shields.io/badge/star-185-f4b400?style=flat-square)](https://github.com/mattolson/agent-sandbox) | sandbox, coding-agents, network-policy | 面向 AI 编码代理的本地锁定沙箱，提供限定文件访问、出站策略、密钥注入、防火墙与持久代理状态。 |
 | HexAgent | [GitHub](https://github.com/UnicomAI/hexagent) | [![star](https://img.shields.io/badge/star-124-f4b400?style=flat-square)](https://github.com/UnicomAI/hexagent) | computer-layer, sandbox, runtime | 将代理运行时与其操作的计算机分离的 agent harness，支持本地、VM 与云端沙箱后端。 |
 | terminal-bench-env | [GitHub](https://github.com/ucsb-mlsec/terminal-bench-env) | [![star](https://img.shields.io/badge/star-70-f4b400?style=flat-square)](https://github.com/ucsb-mlsec/terminal-bench-env) | terminal, benchmark-env, sandbox | 为终端代理基准测试提供执行环境层。 |
+| cc-sandbox-server | [GitHub](https://github.com/weijiafu14/cc-sandbox-server) | - | split-brain, sandbox, claude-code | 面向 Claude Code 兼容运行时的「脑手分离」式沙箱——harness、session 与凭据留在 host，只把工具执行转发进一次性沙箱，并支持崩溃无缝恢复。 |
 
 <a id="protocols-tool-interfaces-agent-contracts"></a>
 ### Protocols, Tool Interfaces & Agent Contracts

--- a/data/projects.yaml
+++ b/data/projects.yaml
@@ -4771,3 +4771,16 @@ entries:
   updated_at: '2025-01-01'
   license: n/a
   why_included: High-signal practitioner framing for harness-first implementation.
+- name: cc-sandbox-server
+  repo_url: https://github.com/weijiafu14/cc-sandbox-server
+  category: Execution Substrates & Sandboxing
+  summary_en: Split-brain sandboxing for Claude Code-compatible runtimes — keeps the harness, session, and credentials on the host and forwards only tool execution into a disposable sandbox, with seamless crash recovery.
+  summary_zh: 面向 Claude Code 兼容运行时的「脑手分离」式沙箱——harness、session 与凭据留在 host，只把工具执行转发进一次性沙箱，并支持崩溃无缝恢复。
+  tags:
+  - split-brain
+  - sandbox
+  - claude-code
+  stars_snapshot: 0
+  updated_at: '2026-06-12'
+  license: Apache-2.0
+  why_included: An open-source implementation of the "decouple the brain from the hands" architecture featured in the list's blogs — the harness stays outside the sandbox, distinct from the whole-agent-in-a-container substrates alongside it.

--- a/reports/verification/2026-07-01.md
+++ b/reports/verification/2026-07-01.md
@@ -1,0 +1,67 @@
+# Verification Report
+
+- Generated at: `2026-07-01T14:47:37.530686+00:00`
+- Total entries: `339`
+- GitHub entries: `312` (92.0%)
+- GitHub in project categories (excluding `Essential Readings & Ecosystem Maps`): `307/307` (100.0%)
+- Categories: `9`
+- URL checks: `340` total, `340` reachable, `0` broken
+
+## Category Counts
+
+| Category | Entries |
+| --- | ---: |
+| Harness Architecture & Orchestration | 57 |
+| Context & Working-State Engineering | 24 |
+| Execution Substrates & Sandboxing | 28 |
+| Protocols, Tool Interfaces & Agent Contracts | 41 |
+| Evaluation Harnesses & Benchmarks | 29 |
+| Observability & Reliability Operations | 20 |
+| Guardrails, Security & Governance | 26 |
+| Reference Harness Implementations | 82 |
+| Essential Readings & Ecosystem Maps | 32 |
+
+## Structural Errors
+
+- None
+
+## Warnings
+
+- None
+
+## Broken URLs
+
+- None
+
+## Reachable URL Sample
+
+- `HEAD 200` https://blog.langchain.com/agent-frameworks-runtimes-and-harnesses-oh-my/
+- `HEAD 200` https://blog.langchain.com/evaluating-deep-agents-our-learnings/
+- `HEAD 200` https://blog.langchain.com/improving-deep-agents-with-harness-engineering/
+- `HEAD 200` https://blog.langchain.com/the-anatomy-of-an-agent-harness/
+- `HEAD 200` https://code.claude.com/docs/en/agent-sdk/overview
+- `HEAD 200` https://cognition.ai/blog/what-we-learned-building-cloud-agents
+- `HEAD 200` https://developers.openai.com/blog/eval-skills
+- `HEAD 200` https://github.com/1jehuang/jcode
+- `HEAD 200` https://github.com/21st-dev/1code
+- `HEAD 200` https://github.com/2FastLabs/agent-squad
+- `HEAD 200` https://github.com/AVIDS2/memorix
+- `HEAD 200` https://github.com/AgentOps-AI/agentops
+- `HEAD 200` https://github.com/Agenta-AI/agenta
+- `HEAD 200` https://github.com/Aider-AI/aider
+- `HEAD 200` https://github.com/AndyMik90/Aperant
+- `HEAD 200` https://github.com/Arize-ai/openinference
+- `HEAD 200` https://github.com/Arize-ai/phoenix
+- `HEAD 200` https://github.com/Atmosphere/atmosphere
+- `HEAD 200` https://github.com/BerriAI/litellm
+- `HEAD 200` https://github.com/BloopAI/vibe-kanban
+- `HEAD 200` https://github.com/BuilderIO/skills
+- `HEAD 200` https://github.com/Chachamaru127/claude-code-harness
+- `HEAD 200` https://github.com/Chorus-AIDLC/Chorus
+- `HEAD 200` https://github.com/ChromeDevTools/chrome-devtools-mcp
+- `HEAD 200` https://github.com/ComposioHQ/agent-orchestrator
+- `HEAD 200` https://github.com/DevAgentForge/Open-Claude-Cowork
+- `HEAD 200` https://github.com/EleutherAI/lm-evaluation-harness
+- `HEAD 200` https://github.com/EverMind-AI/EverOS
+- `HEAD 200` https://github.com/EveryInc/compound-engineering-plugin
+- `HEAD 200` https://github.com/FoundationAgents/OpenManus


### PR DESCRIPTION
Adds **cc-sandbox-server** under *Execution Substrates & Sandboxing*.

This list already features Anthropic's **_Scaling Managed Agents: Decoupling the brain from the hands_** as a Featured Blog, but no catalog entry implements that pattern. `cc-sandbox-server` is an open-source implementation of it for Claude Code-compatible runtimes:

- The **harness, session, and credentials stay on the host**; only *tool execution* is forwarded into a disposable sandbox over one persistent connection.
- Same binary runs agent mode on the host and `--tool-server` mode in the sandbox, so tool behavior is byte-for-byte identical (no reimplemented Glob/Grep/Edit).
- The sandbox is **cattle, not a pet** — on crash the host reconnects to a rebuilt one and the turn continues; in-flight idempotent tools auto-retry.

This is distinct from the whole-agent-in-a-container substrates alongside it (Daytona, E2B, OpenSandbox, …): those *run* code in a box; this decides what crosses the boundary and keeps the brain out of it.

- Repo: https://github.com/weijiafu14/cc-sandbox-server (Apache-2.0, TypeScript, active)
- Edited only \`data/projects.yaml\`; re-ran \`render_readme.py\` and \`verify_catalog.py\` (**Verification passed**), committed the regenerated READMEs + report.

Checklist:
- [x] Link is reachable
- [x] Category is correct
- [x] Summary is concise and practical
- [x] Mirrors render cleanly in both READMEs