### PR TITLE
Add Tree Ring Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A curated, implementation-first list of **agent harness engineering** resources, with GitHub projects as the primary focus.
 
-- Total entries: **338**
-- GitHub entries: **311 (92.0%)**
-- GitHub in project categories (excluding readings): **306/306 (100.0%)**
+- Total entries: **339**
+- GitHub entries: **312 (92.0%)**
+- GitHub in project categories (excluding readings): **307/307 (100.0%)**
 - Categories: **9**
 - Last verified: **2026-06-21**
 - Language: [English](./README.md) | [中文](./README_zh.md)
@@ -47,7 +47,7 @@ A curated, implementation-first list of **agent harness engineering** resources,
 | Category | Entries |
 | --- | ---: |
 | Harness Architecture & Orchestration | 57 |
-| Context & Working-State Engineering | 24 |
+| Context & Working-State Engineering | 25 |
 | Execution Substrates & Sandboxing | 27 |
 | Protocols, Tool Interfaces & Agent Contracts | 41 |
 | Evaluation Harnesses & Benchmarks | 29 |
@@ -155,6 +155,7 @@ Notes:
 | context-space | [GitHub](https://github.com/context-space/context-space) | [![star](https://img.shields.io/badge/star-810-f4b400?style=flat-square)](https://github.com/context-space/context-space) | context, infrastructure, mcp | Infrastructure project focused on context engineering building blocks and MCP-centric integrations. |
 | Memorix | [GitHub](https://github.com/AVIDS2/memorix) | [![star](https://img.shields.io/badge/star-510-f4b400?style=flat-square)](https://github.com/AVIDS2/memorix) | memory, mcp, cross-agent | Local-first cross-agent memory control plane with MCP support, workspace sync, sessions, and orchestration state. |
 | sd0x-dev-flow | [GitHub](https://github.com/sd0xdev/sd0x-dev-flow) | [![star](https://img.shields.io/badge/star-170-f4b400?style=flat-square)](https://github.com/sd0xdev/sd0x-dev-flow) | hooks, state-machine, claude-code | Claude Code harness layer with hook-enforced dual review, durable state-machine gates, context-compaction recovery, and fail-closed safety. |
+| Tree Ring Memory | [GitHub](https://github.com/TerminallyLazy/Tree-Ring-Memory) | [![star](https://img.shields.io/badge/star-2-f4b400?style=flat-square)](https://github.com/TerminallyLazy/Tree-Ring-Memory) | memory, local-first, cli | Framework-agnostic local-first memory lifecycle for AI agents with Rust CLI/TUI operation, SQLite/FTS recall, forgetting, audit, and consolidation. |
 
 <a id="execution-substrates-sandboxing"></a>
 ### Execution Substrates & Sandboxing

--- a/README_zh.md
+++ b/README_zh.md
@@ -2,9 +2,9 @@
 
 一个面向 **Agent Harness Engineering** 的工程实践清单，优先收录可直接落地的 GitHub 项目。
 
-- 当前条目数: **338**
-- GitHub 条目: **311 (92.0%)**
-- 项目分类 GitHub 占比（不含阅读类）: **306/306 (100.0%)**
+- 当前条目数: **339**
+- GitHub 条目: **312 (92.0%)**
+- 项目分类 GitHub 占比（不含阅读类）: **307/307 (100.0%)**
 - 分类数量: **9**
 - 最近核对日期: **2026-06-21**
 - 语言: [English](./README.md) | [中文](./README_zh.md)
@@ -47,7 +47,7 @@
 | 分类 | 条目数 |
 | --- | ---: |
 | Harness Architecture & Orchestration | 57 |
-| Context & Working-State Engineering | 24 |
+| Context & Working-State Engineering | 25 |
 | Execution Substrates & Sandboxing | 27 |
 | Protocols, Tool Interfaces & Agent Contracts | 41 |
 | Evaluation Harnesses & Benchmarks | 29 |
@@ -155,6 +155,7 @@
 | context-space | [GitHub](https://github.com/context-space/context-space) | [![star](https://img.shields.io/badge/star-810-f4b400?style=flat-square)](https://github.com/context-space/context-space) | context, infrastructure, mcp | 聚焦上下文工程基础设施的项目，强调 MCP 生态集成能力。 |
 | Memorix | [GitHub](https://github.com/AVIDS2/memorix) | [![star](https://img.shields.io/badge/star-510-f4b400?style=flat-square)](https://github.com/AVIDS2/memorix) | memory, mcp, cross-agent | 本地优先的跨代理记忆控制平面，支持 MCP、工作区同步、会话与编排状态。 |
 | sd0x-dev-flow | [GitHub](https://github.com/sd0xdev/sd0x-dev-flow) | [![star](https://img.shields.io/badge/star-170-f4b400?style=flat-square)](https://github.com/sd0xdev/sd0x-dev-flow) | hooks, state-machine, claude-code | Claude Code harness 层，提供钩子强制双重评审、持久状态机门禁、上下文压缩恢复与 fail-closed 安全机制。 |
+| Tree Ring Memory | [GitHub](https://github.com/TerminallyLazy/Tree-Ring-Memory) | [![star](https://img.shields.io/badge/star-2-f4b400?style=flat-square)](https://github.com/TerminallyLazy/Tree-Ring-Memory) | memory, local-first, cli | 面向 AI 代理的框架无关本地优先记忆生命周期，提供 Rust CLI/TUI、SQLite/FTS 召回、遗忘、审计与合并。 |
 
 <a id="execution-substrates-sandboxing"></a>
 ### Execution Substrates & Sandboxing

--- a/data/projects.yaml
+++ b/data/projects.yaml
@@ -1196,6 +1196,21 @@ entries:
   license: MIT
   why_included: README maps concrete code to harness sub-problems including state-machine gates, lifecycle interceptors, context
     recovery across compaction, tool gating, and review loops.
+- name: Tree Ring Memory
+  repo_url: https://github.com/TerminallyLazy/Tree-Ring-Memory
+  category: Context & Working-State Engineering
+  summary_en: Framework-agnostic local-first memory lifecycle for AI agents with Rust CLI/TUI operation, SQLite/FTS recall,
+    forgetting, audit, and consolidation.
+  summary_zh: 面向 AI 代理的框架无关本地优先记忆生命周期，提供 Rust CLI/TUI、SQLite/FTS 召回、遗忘、审计与合并。
+  tags:
+  - memory
+  - local-first
+  - cli
+  stars_snapshot: 2
+  updated_at: '2026-07-07'
+  license: NOASSERTION
+  why_included: README documents a concrete local-first memory lifecycle for AI agents with recall, forgetting, audit reports,
+    consolidation, CLI/TUI operation, and SQLite/FTS storage.
 - name: Daytona
   repo_url: https://github.com/daytonaio/daytona
   category: Execution Substrates & Sandboxing

--- a/reports/verification/2026-07-07.md
+++ b/reports/verification/2026-07-07.md
@@ -1,0 +1,67 @@
+# Verification Report
+
+- Generated at: `2026-07-07T14:48:10.797320+00:00`
+- Total entries: `339`
+- GitHub entries: `312` (92.0%)
+- GitHub in project categories (excluding `Essential Readings & Ecosystem Maps`): `307/307` (100.0%)
+- Categories: `9`
+- URL checks: `340` total, `340` reachable, `0` broken
+
+## Category Counts
+
+| Category | Entries |
+| --- | ---: |
+| Harness Architecture & Orchestration | 57 |
+| Context & Working-State Engineering | 25 |
+| Execution Substrates & Sandboxing | 27 |
+| Protocols, Tool Interfaces & Agent Contracts | 41 |
+| Evaluation Harnesses & Benchmarks | 29 |
+| Observability & Reliability Operations | 20 |
+| Guardrails, Security & Governance | 26 |
+| Reference Harness Implementations | 82 |
+| Essential Readings & Ecosystem Maps | 32 |
+
+## Structural Errors
+
+- None
+
+## Warnings
+
+- None
+
+## Broken URLs
+
+- None
+
+## Reachable URL Sample
+
+- `HEAD 200` https://blog.langchain.com/agent-frameworks-runtimes-and-harnesses-oh-my/
+- `HEAD 200` https://blog.langchain.com/evaluating-deep-agents-our-learnings/
+- `HEAD 200` https://blog.langchain.com/improving-deep-agents-with-harness-engineering/
+- `HEAD 200` https://blog.langchain.com/the-anatomy-of-an-agent-harness/
+- `HEAD 200` https://code.claude.com/docs/en/agent-sdk/overview
+- `HEAD 200` https://cognition.ai/blog/what-we-learned-building-cloud-agents
+- `HEAD 200` https://developers.openai.com/blog/eval-skills
+- `HEAD 200` https://github.com/1jehuang/jcode
+- `HEAD 200` https://github.com/21st-dev/1code
+- `HEAD 200` https://github.com/2FastLabs/agent-squad
+- `HEAD 200` https://github.com/AVIDS2/memorix
+- `HEAD 200` https://github.com/AgentOps-AI/agentops
+- `HEAD 200` https://github.com/Agenta-AI/agenta
+- `HEAD 200` https://github.com/Aider-AI/aider
+- `HEAD 200` https://github.com/AndyMik90/Aperant
+- `HEAD 200` https://github.com/Arize-ai/openinference
+- `HEAD 200` https://github.com/Arize-ai/phoenix
+- `HEAD 200` https://github.com/Atmosphere/atmosphere
+- `HEAD 200` https://github.com/BerriAI/litellm
+- `HEAD 200` https://github.com/BloopAI/vibe-kanban
+- `HEAD 200` https://github.com/BuilderIO/skills
+- `HEAD 200` https://github.com/Chachamaru127/claude-code-harness
+- `HEAD 200` https://github.com/Chorus-AIDLC/Chorus
+- `HEAD 200` https://github.com/ChromeDevTools/chrome-devtools-mcp
+- `HEAD 200` https://github.com/ComposioHQ/agent-orchestrator
+- `HEAD 200` https://github.com/DevAgentForge/Open-Claude-Cowork
+- `HEAD 200` https://github.com/EleutherAI/lm-evaluation-harness
+- `HEAD 200` https://github.com/EverMind-AI/EverOS
+- `HEAD 200` https://github.com/EveryInc/compound-engineering-plugin
+- `HEAD 200` https://github.com/FoundationAgents/OpenManus


### PR DESCRIPTION
## Summary
- Add Tree Ring Memory to Context & Working-State Engineering
- Regenerate English and Chinese README catalog counts/rows
- Add the 2026-07-07 verification report

## Validation
- python3 scripts/render_readme.py
- python3 scripts/verify_catalog.py
- git diff --check
- Tree Ring Memory URL checked separately: HTTP 200