### PR TITLE
Add Agentlas OS to Harness Architecture and Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A curated, implementation-first list of **agent harness engineering** resources, with GitHub projects as the primary focus.
 
-- Total entries: **358**
-- GitHub entries: **324 (90.5%)**
-- GitHub in project categories (excluding readings): **319/319 (100.0%)**
+- Total entries: **357**
+- GitHub entries: **323 (90.5%)**
+- GitHub in project categories (excluding readings): **318/318 (100.0%)**
 - Categories: **9**
 - Last verified: **2026-08-24**
 - Language: [English](./README.md) | [中文](./README_zh.md)
@@ -51,12 +51,12 @@ A curated, implementation-first list of **agent harness engineering** resources,
 
 | Category | Entries |
 | --- | ---: |
-| Harness Architecture & Orchestration | 62 |
+| Harness Architecture & Orchestration | 63 |
 | Context & Working-State Engineering | 27 |
 | Execution Substrates & Sandboxing | 27 |
-| Protocols, Tool Interfaces & Agent Contracts | 42 |
+| Protocols, Tool Interfaces & Agent Contracts | 41 |
 | Evaluation Harnesses & Benchmarks | 29 |
-| Observability & Reliability Operations | 20 |
+| Observability & Reliability Operations | 19 |
 | Guardrails, Security & Governance | 26 |
 | Reference Harness Implementations | 86 |
 | Essential Readings & Ecosystem Maps | 39 |
@@ -131,6 +131,7 @@ Notes:
 | oh-my-agent | [GitHub](https://github.com/first-fluke/oh-my-agent) | [![star](https://img.shields.io/badge/star-1245-f4b400?style=flat-square)](https://github.com/first-fluke/oh-my-agent) | multi-agent, skills, cross-runtime | Portable multi-agent harness that projects shared agents, skills, workflows, and rules into multiple coding-agent runtimes. |
 | LiteLLM Agent Control Plane | [GitHub](https://github.com/LiteLLM-Labs/litellm-agent-control-plane) | [![star](https://img.shields.io/badge/star-1229-f4b400?style=flat-square)](https://github.com/LiteLLM-Labs/litellm-agent-control-plane) | control-plane, sessions, runtime | Agent control plane that provides one API and UI across OpenCode, Hermes, Claude Managed Agents, Cursor Agents API, DeepAgents, and OpenClaw runtimes. |
 | Chorus | [GitHub](https://github.com/Chorus-AIDLC/Chorus) | [![star](https://img.shields.io/badge/star-1150-f4b400?style=flat-square)](https://github.com/Chorus-AIDLC/Chorus) | ai-dlc, permissions, task-state | AI-human collaboration harness for session lifecycle, task state, sub-agent orchestration, observability, and recovery. |
+| Agentlas OS | [GitHub](https://github.com/agentlas-ai/Agentlas-OS) | [![star](https://img.shields.io/badge/star-1115-f4b400?style=flat-square)](https://github.com/agentlas-ai/Agentlas-OS) | agent-os, cross-harness, governance | Local-first agent operation environment that builds portable agent and team packages and routes them across supported coding hosts with governed memory, policy gates, MCP/A2A boundaries, and verification receipts. |
 | Pydantic AI Harness | [GitHub](https://github.com/pydantic/pydantic-ai-harness) | [![star](https://img.shields.io/badge/star-805-f4b400?style=flat-square)](https://github.com/pydantic/pydantic-ai-harness) | capabilities, hooks, pydantic | Official Pydantic AI capability library for composing tools, lifecycle hooks, instructions, and model settings into reusable agent harnesses. |
 | Water | [GitHub](https://github.com/manthanguptaa/water) | [![star](https://img.shields.io/badge/star-334-f4b400?style=flat-square)](https://github.com/manthanguptaa/water) | python, framework, approval-gates | Python agent harness framework for orchestration, resilience, observability, guardrails, approval gates, sandboxing, and deployment. |
 | OmniCoreAgent | [GitHub](https://github.com/omnirexflora-labs/omnicoreagent) | [![star](https://img.shields.io/badge/star-245-f4b400?style=flat-square)](https://github.com/omnirexflora-labs/omnicoreagent) | python, mcp, serving | Python production harness with model loop, tools, MCP, memory, workspace files, guardrails, events, subagents, background tasks, and REST/SSE serving. |
@@ -248,7 +249,6 @@ Notes:
 | OpenGAP | [GitHub](https://github.com/open-gitagent/opengap) | [![star](https://img.shields.io/badge/star-2920-f4b400?style=flat-square)](https://github.com/open-gitagent/opengap) | git-native, cli, agent-contract | Reference CLI for the Git Agent Protocol, turning repository files into portable agent manifests, rules, skills, workflows, tools, memory, hooks, and compliance contracts. |
 | Microsoft Learn MCP | [GitHub](https://github.com/MicrosoftDocs/mcp) | [![star](https://img.shields.io/badge/star-1853-f4b400?style=flat-square)](https://github.com/MicrosoftDocs/mcp) | mcp, docs, grounding | MCP server and CLI for grounding agents with Microsoft documentation sources. |
 | IBM MCP | [GitHub](https://github.com/IBM/mcp) | [![star](https://img.shields.io/badge/star-401-f4b400?style=flat-square)](https://github.com/IBM/mcp) | mcp, clients, tooling | IBM collection of MCP servers, clients, and developer tooling. |
-| AGENT.md | [GitHub](https://github.com/agentmd/agent.md) | [![star](https://img.shields.io/badge/star-89-f4b400?style=flat-square)](https://github.com/agentmd/agent.md) | standard, agent-file, interoperability | Standardized machine-readable file format for agentic coding tools. |
 
 <a id="evaluation-harnesses-benchmarks"></a>
 ### Evaluation Harnesses & Benchmarks
@@ -305,7 +305,6 @@ Notes:
 | Laminar | [GitHub](https://github.com/lmnr-ai/lmnr) | [![star](https://img.shields.io/badge/star-3187-f4b400?style=flat-square)](https://github.com/lmnr-ai/lmnr) | observability, tracing, evals | Agent-focused observability stack with tracing, evaluation runs, monitoring, and dashboards. |
 | Desloppify | [GitHub](https://github.com/peteromallet/desloppify) | [![star](https://img.shields.io/badge/star-3029-f4b400?style=flat-square)](https://github.com/peteromallet/desloppify) | quality-gates, codebase-health, ci | Agent-facing codebase quality harness with scans, scoring, LLM review, prioritized fix loops, persistent state, and CI gates. |
 | OpenLIT | [GitHub](https://github.com/openlit/openlit) | [![star](https://img.shields.io/badge/star-2714-f4b400?style=flat-square)](https://github.com/openlit/openlit) | opentelemetry, observability, evaluations | OpenTelemetry-native AI engineering platform for LLM and coding-agent observability, evaluations, guardrails, prompt management, secrets, and dashboards. |
-| claude-code-reverse | [GitHub](https://github.com/Yuyz0112/claude-code-reverse) | [![star](https://img.shields.io/badge/star-2427-f4b400?style=flat-square)](https://github.com/Yuyz0112/claude-code-reverse) | trace, visualization, debugging | Tooling to visualize and inspect Claude Code LLM interaction traces. |
 | Future AGI | [GitHub](https://github.com/future-agi/future-agi) | [![star](https://img.shields.io/badge/star-1795-f4b400?style=flat-square)](https://github.com/future-agi/future-agi) | observability, evaluation, guardrails | Self-hostable platform that closes the loop across agent tracing, evaluation, simulation, guardrails, and gateway operations. |
 | OpenInference | [GitHub](https://github.com/Arize-ai/openinference) | [![star](https://img.shields.io/badge/star-1167-f4b400?style=flat-square)](https://github.com/Arize-ai/openinference) | spec, instrumentation, observability | Open instrumentation specification and tooling for AI observability. |
 | Judgeval | [GitHub](https://github.com/JudgmentLabs/judgeval) | [![star](https://img.shields.io/badge/star-1058-f4b400?style=flat-square)](https://github.com/JudgmentLabs/judgeval) | tracing, agent-judges, monitoring | Agent improvement SDK with OpenTelemetry tracing, agent judges, online monitoring, replay evaluations, CLI workflows, and MCP access to traces and behaviors. |

--- a/README_zh.md
+++ b/README_zh.md
@@ -2,9 +2,9 @@
 
 一个面向 **Agent Harness Engineering** 的工程实践清单，优先收录可直接落地的 GitHub 项目。
 
-- 当前条目数: **358**
-- GitHub 条目: **324 (90.5%)**
-- 项目分类 GitHub 占比（不含阅读类）: **319/319 (100.0%)**
+- 当前条目数: **357**
+- GitHub 条目: **323 (90.5%)**
+- 项目分类 GitHub 占比（不含阅读类）: **318/318 (100.0%)**
 - 分类数量: **9**
 - 最近核对日期: **2026-08-24**
 - 语言: [English](./README.md) | [中文](./README_zh.md)
@@ -51,12 +51,12 @@
 
 | 分类 | 条目数 |
 | --- | ---: |
-| Harness Architecture & Orchestration | 62 |
+| Harness Architecture & Orchestration | 63 |
 | Context & Working-State Engineering | 27 |
 | Execution Substrates & Sandboxing | 27 |
-| Protocols, Tool Interfaces & Agent Contracts | 42 |
+| Protocols, Tool Interfaces & Agent Contracts | 41 |
 | Evaluation Harnesses & Benchmarks | 29 |
-| Observability & Reliability Operations | 20 |
+| Observability & Reliability Operations | 19 |
 | Guardrails, Security & Governance | 26 |
 | Reference Harness Implementations | 86 |
 | Essential Readings & Ecosystem Maps | 39 |
@@ -131,6 +131,7 @@
 | oh-my-agent | [GitHub](https://github.com/first-fluke/oh-my-agent) | [![star](https://img.shields.io/badge/star-1245-f4b400?style=flat-square)](https://github.com/first-fluke/oh-my-agent) | multi-agent, skills, cross-runtime | 可移植多代理 harness，可将共享代理、技能、工作流与规则投射到多个编码代理运行时。 |
 | LiteLLM Agent Control Plane | [GitHub](https://github.com/LiteLLM-Labs/litellm-agent-control-plane) | [![star](https://img.shields.io/badge/star-1229-f4b400?style=flat-square)](https://github.com/LiteLLM-Labs/litellm-agent-control-plane) | control-plane, sessions, runtime | 面向 OpenCode、Hermes、Claude Managed Agents、Cursor Agents API、DeepAgents 与 OpenClaw 等运行时的一体化代理控制平面。 |
 | Chorus | [GitHub](https://github.com/Chorus-AIDLC/Chorus) | [![star](https://img.shields.io/badge/star-1150-f4b400?style=flat-square)](https://github.com/Chorus-AIDLC/Chorus) | ai-dlc, permissions, task-state | 面向人机协作的 harness，管理会话生命周期、任务状态、子代理编排、可观测性与故障恢复。 |
+| Agentlas OS | [GitHub](https://github.com/agentlas-ai/Agentlas-OS) | [![star](https://img.shields.io/badge/star-1115-f4b400?style=flat-square)](https://github.com/agentlas-ai/Agentlas-OS) | agent-os, cross-harness, governance | 本地优先的代理操作环境，可构建可移植的代理与团队包，并跨受支持的编码主机进行路由，同时提供受治理的记忆、策略门禁、MCP/A2A 边界与验证回执。 |
 | Pydantic AI Harness | [GitHub](https://github.com/pydantic/pydantic-ai-harness) | [![star](https://img.shields.io/badge/star-805-f4b400?style=flat-square)](https://github.com/pydantic/pydantic-ai-harness) | capabilities, hooks, pydantic | Pydantic AI 官方能力库，可将工具、生命周期钩子、指令与模型设置组合为可复用的 agent harness。 |
 | Water | [GitHub](https://github.com/manthanguptaa/water) | [![star](https://img.shields.io/badge/star-334-f4b400?style=flat-square)](https://github.com/manthanguptaa/water) | python, framework, approval-gates | Python agent harness 框架，覆盖编排、韧性、可观测性、护栏、审批门禁、沙箱与部署。 |
 | OmniCoreAgent | [GitHub](https://github.com/omnirexflora-labs/omnicoreagent) | [![star](https://img.shields.io/badge/star-245-f4b400?style=flat-square)](https://github.com/omnirexflora-labs/omnicoreagent) | python, mcp, serving | Python 生产级 harness，包含模型循环、工具、MCP、记忆、工作区文件、护栏、事件、子代理、后台任务与 REST/SSE 服务。 |
@@ -248,7 +249,6 @@
 | OpenGAP | [GitHub](https://github.com/open-gitagent/opengap) | [![star](https://img.shields.io/badge/star-2920-f4b400?style=flat-square)](https://github.com/open-gitagent/opengap) | git-native, cli, agent-contract | Git Agent Protocol 的参考 CLI，可将仓库文件组织成可移植的代理 manifest、规则、技能、工作流、工具、记忆、钩子与合规契约。 |
 | Microsoft Learn MCP | [GitHub](https://github.com/MicrosoftDocs/mcp) | [![star](https://img.shields.io/badge/star-1853-f4b400?style=flat-square)](https://github.com/MicrosoftDocs/mcp) | mcp, docs, grounding | 为代理接入微软文档知识提供的 MCP server 与 CLI。 |
 | IBM MCP | [GitHub](https://github.com/IBM/mcp) | [![star](https://img.shields.io/badge/star-401-f4b400?style=flat-square)](https://github.com/IBM/mcp) | mcp, clients, tooling | IBM 提供的 MCP server、client 与开发工具集合。 |
-| AGENT.md | [GitHub](https://github.com/agentmd/agent.md) | [![star](https://img.shields.io/badge/star-89-f4b400?style=flat-square)](https://github.com/agentmd/agent.md) | standard, agent-file, interoperability | 面向代理编码工具的标准化机器可读文件格式。 |
 
 <a id="evaluation-harnesses-benchmarks"></a>
 ### Evaluation Harnesses & Benchmarks
@@ -305,7 +305,6 @@
 | Laminar | [GitHub](https://github.com/lmnr-ai/lmnr) | [![star](https://img.shields.io/badge/star-3187-f4b400?style=flat-square)](https://github.com/lmnr-ai/lmnr) | observability, tracing, evals | 面向代理系统的可观测平台，覆盖追踪、评测运行、监控与仪表盘。 |
 | Desloppify | [GitHub](https://github.com/peteromallet/desloppify) | [![star](https://img.shields.io/badge/star-3029-f4b400?style=flat-square)](https://github.com/peteromallet/desloppify) | quality-gates, codebase-health, ci | 面向编码代理的代码库质量 harness，提供扫描、评分、LLM 评审、优先级修复循环、持久状态与 CI 门禁。 |
 | OpenLIT | [GitHub](https://github.com/openlit/openlit) | [![star](https://img.shields.io/badge/star-2714-f4b400?style=flat-square)](https://github.com/openlit/openlit) | opentelemetry, observability, evaluations | OpenTelemetry 原生 AI 工程平台，覆盖 LLM 与编码代理可观测性、评测、护栏、提示词管理、密钥与仪表盘。 |
-| claude-code-reverse | [GitHub](https://github.com/Yuyz0112/claude-code-reverse) | [![star](https://img.shields.io/badge/star-2427-f4b400?style=flat-square)](https://github.com/Yuyz0112/claude-code-reverse) | trace, visualization, debugging | 可视化并分析 Claude Code 大模型交互链路的工具。 |
 | Future AGI | [GitHub](https://github.com/future-agi/future-agi) | [![star](https://img.shields.io/badge/star-1795-f4b400?style=flat-square)](https://github.com/future-agi/future-agi) | observability, evaluation, guardrails | 可自托管的平台，将代理追踪、评测、模拟、护栏与网关运维闭环整合在一起。 |
 | OpenInference | [GitHub](https://github.com/Arize-ai/openinference) | [![star](https://img.shields.io/badge/star-1167-f4b400?style=flat-square)](https://github.com/Arize-ai/openinference) | spec, instrumentation, observability | 面向 AI 可观测性的开放埋点规范与工具。 |
 | Judgeval | [GitHub](https://github.com/JudgmentLabs/judgeval) | [![star](https://img.shields.io/badge/star-1058-f4b400?style=flat-square)](https://github.com/JudgmentLabs/judgeval) | tracing, agent-judges, monitoring | 面向代理改进的 SDK，提供 OpenTelemetry 追踪、agent judge、在线监控、回放评测、CLI 流程与 MCP 访问轨迹/行为。 |

--- a/data/projects.yaml
+++ b/data/projects.yaml
@@ -929,6 +929,19 @@ entries:
   updated_at: '2026-08-18'
   license: Apache-2.0
   why_included: Strong example of a harness runtime built around repairability, rollback, and controlled long-running execution.
+- name: Agentlas OS
+  repo_url: https://github.com/agentlas-ai/Agentlas-OS
+  category: Harness Architecture & Orchestration
+  summary_en: Local-first agent operation environment that builds portable agent and team packages and routes them across supported coding hosts with governed memory, policy gates, MCP/A2A boundaries, and verification receipts.
+  summary_zh: 本地优先的代理操作环境，可构建可移植的代理与团队包，并跨受支持的编码主机进行路由，同时提供受治理的记忆、策略门禁、MCP/A2A 边界与验证回执。
+  tags:
+  - agent-os
+  - cross-harness
+  - governance
+  stars_snapshot: 1115
+  updated_at: '2026-08-28'
+  license: Apache-2.0
+  why_included: The README documents portable agent and team packages, multi-runtime adapters, governed memory, policy gates, browser execution, MCP/A2A contracts, and auditable routing and verification receipts.
 - name: Graphify
   repo_url: https://github.com/Graphify-Labs/graphify
   category: Context & Working-State Engineering
@@ -2273,19 +2286,6 @@ entries:
   updated_at: '2026-07-28'
   license: Apache-2.0
   why_included: Adds vendor-diverse protocol ecosystem coverage.
-- name: AGENT.md
-  repo_url: https://github.com/agentmd/agent.md
-  category: Protocols, Tool Interfaces & Agent Contracts
-  summary_en: Standardized machine-readable file format for agentic coding tools.
-  summary_zh: 面向代理编码工具的标准化机器可读文件格式。
-  tags:
-  - standard
-  - agent-file
-  - interoperability
-  stars_snapshot: 89
-  updated_at: '2025-07-10'
-  license: MIT
-  why_included: Alternative standardization path worth tracking in harness ecosystems.
 - name: Promptfoo
   repo_url: https://github.com/promptfoo/promptfoo
   category: Evaluation Harnesses & Benchmarks
@@ -2881,19 +2881,6 @@ entries:
   license: Apache-2.0
   why_included: README documents OTel-native tracing for Claude Code, Cursor, and Codex sessions, prompts, tool calls, file
     edits, subagent spawns, costs, evaluations, guardrails, and framework integrations.
-- name: claude-code-reverse
-  repo_url: https://github.com/Yuyz0112/claude-code-reverse
-  category: Observability & Reliability Operations
-  summary_en: Tooling to visualize and inspect Claude Code LLM interaction traces.
-  summary_zh: 可视化并分析 Claude Code 大模型交互链路的工具。
-  tags:
-  - trace
-  - visualization
-  - debugging
-  stars_snapshot: 2427
-  updated_at: '2025-08-26'
-  license: none
-  why_included: Useful lightweight approach for harness behavior introspection.
 - name: Future AGI
   repo_url: https://github.com/future-agi/future-agi
   category: Observability & Reliability Operations

--- a/reports/verification/2026-08-30.md
+++ b/reports/verification/2026-08-30.md
@@ -1,0 +1,36 @@
+# Verification Report
+
+- Generated at: `2026-08-29T23:59:06.920322+00:00`
+- Total entries: `357`
+- GitHub entries: `323` (90.5%)
+- GitHub in project categories (excluding `Essential Readings & Ecosystem Maps`): `318/318` (100.0%)
+- Categories: `9`
+- URL checks: `0` total, `0` reachable, `0` broken
+
+## Category Counts
+
+| Category | Entries |
+| --- | ---: |
+| Harness Architecture & Orchestration | 63 |
+| Context & Working-State Engineering | 27 |
+| Execution Substrates & Sandboxing | 27 |
+| Protocols, Tool Interfaces & Agent Contracts | 41 |
+| Evaluation Harnesses & Benchmarks | 29 |
+| Observability & Reliability Operations | 19 |
+| Guardrails, Security & Governance | 26 |
+| Reference Harness Implementations | 86 |
+| Essential Readings & Ecosystem Maps | 39 |
+
+## Structural Errors
+
+- None
+
+## Warnings
+
+- None
+
+## Broken URLs
+
+- None
+
+## Reachable URL Sample


### PR DESCRIPTION
## Summary

Adds Agentlas OS to Harness Architecture and Orchestration from the catalog source of truth.

The source entry includes English and Chinese summaries, current repository metadata, and an evidence-based inclusion rationale. README.md and README_zh.md were regenerated from data/projects.yaml.

## Catalog maintenance required by the current validator

The current >12-month activity gate also required removing two unrelated stale entries (AGENT.md and claude-code-reverse). Those removals are generated consistently into both README mirrors.

## Verification

- python3 scripts/render_readme.py: passed
- python3 scripts/verify_catalog.py --skip-links: passed (357 entries, no structural errors or warnings)
- Full URL checking reached one pre-existing external blocker: https://openreview.net/pdf?id=eONq7FdiHa returns HTTP 403
- git diff --check: passed

Disclosure: I am submitting this entry on behalf of the Agentlas project.