### PR TITLE
Add OpenAgentRelay runtime boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A curated, implementation-first list of **agent harness engineering** resources, with GitHub projects as the primary focus.
 
-- Total entries: **338**
-- GitHub entries: **311 (92.0%)**
-- GitHub in project categories (excluding readings): **306/306 (100.0%)**
+- Total entries: **339**
+- GitHub entries: **312 (92.0%)**
+- GitHub in project categories (excluding readings): **307/307 (100.0%)**
 - Categories: **9**
 - Last verified: **2026-06-21**
 - Language: [English](./README.md) | [中文](./README_zh.md)
@@ -46,7 +46,7 @@ A curated, implementation-first list of **agent harness engineering** resources,
 
 | Category | Entries |
 | --- | ---: |
-| Harness Architecture & Orchestration | 57 |
+| Harness Architecture & Orchestration | 58 |
 | Context & Working-State Engineering | 24 |
 | Execution Substrates & Sandboxing | 27 |
 | Protocols, Tool Interfaces & Agent Contracts | 41 |
@@ -125,6 +125,7 @@ Notes:
 | Water | [GitHub](https://github.com/manthanguptaa/water) | [![star](https://img.shields.io/badge/star-292-f4b400?style=flat-square)](https://github.com/manthanguptaa/water) | python, framework, approval-gates | Python agent harness framework for orchestration, resilience, observability, guardrails, approval gates, sandboxing, and deployment. |
 | OmniCoreAgent | [GitHub](https://github.com/omnirexflora-labs/omnicoreagent) | [![star](https://img.shields.io/badge/star-243-f4b400?style=flat-square)](https://github.com/omnirexflora-labs/omnicoreagent) | python, mcp, serving | Python production harness with model loop, tools, MCP, memory, workspace files, guardrails, events, subagents, background tasks, and REST/SSE serving. |
 | hankweave | [GitHub](https://github.com/SouthBridgeAI/hankweave-runtime) | [![star](https://img.shields.io/badge/star-129-f4b400?style=flat-square)](https://github.com/SouthBridgeAI/hankweave-runtime) | long-horizon, runtime, checkpoints | Headless-first long-horizon runtime that orchestrates existing agent harnesses with sentinels, loops, checkpoints, and event journals. |
+| OpenAgentRelay | [GitHub](https://github.com/ShakespeareLabs/open-agent-relay) | - | remote-delegation, local-first, runtime-boundary | Minimal trusted-LAN boundary that exposes one existing local agent or automation as a keyed, machine-callable capability. |
 
 <a id="context-working-state-engineering"></a>
 ### Context & Working-State Engineering

--- a/README_zh.md
+++ b/README_zh.md
@@ -2,9 +2,9 @@
 
 一个面向 **Agent Harness Engineering** 的工程实践清单，优先收录可直接落地的 GitHub 项目。
 
-- 当前条目数: **338**
-- GitHub 条目: **311 (92.0%)**
-- 项目分类 GitHub 占比（不含阅读类）: **306/306 (100.0%)**
+- 当前条目数: **339**
+- GitHub 条目: **312 (92.0%)**
+- 项目分类 GitHub 占比（不含阅读类）: **307/307 (100.0%)**
 - 分类数量: **9**
 - 最近核对日期: **2026-06-21**
 - 语言: [English](./README.md) | [中文](./README_zh.md)
@@ -46,7 +46,7 @@
 
 | 分类 | 条目数 |
 | --- | ---: |
-| Harness Architecture & Orchestration | 57 |
+| Harness Architecture & Orchestration | 58 |
 | Context & Working-State Engineering | 24 |
 | Execution Substrates & Sandboxing | 27 |
 | Protocols, Tool Interfaces & Agent Contracts | 41 |
@@ -125,6 +125,7 @@
 | Water | [GitHub](https://github.com/manthanguptaa/water) | [![star](https://img.shields.io/badge/star-292-f4b400?style=flat-square)](https://github.com/manthanguptaa/water) | python, framework, approval-gates | Python agent harness 框架，覆盖编排、韧性、可观测性、护栏、审批门禁、沙箱与部署。 |
 | OmniCoreAgent | [GitHub](https://github.com/omnirexflora-labs/omnicoreagent) | [![star](https://img.shields.io/badge/star-243-f4b400?style=flat-square)](https://github.com/omnirexflora-labs/omnicoreagent) | python, mcp, serving | Python 生产级 harness，包含模型循环、工具、MCP、记忆、工作区文件、护栏、事件、子代理、后台任务与 REST/SSE 服务。 |
 | hankweave | [GitHub](https://github.com/SouthBridgeAI/hankweave-runtime) | [![star](https://img.shields.io/badge/star-129-f4b400?style=flat-square)](https://github.com/SouthBridgeAI/hankweave-runtime) | long-horizon, runtime, checkpoints | 面向长任务的无界面运行时，可编排现有 agent harness，并提供 sentinels、循环、检查点与事件日志。 |
+| OpenAgentRelay | [GitHub](https://github.com/ShakespeareLabs/open-agent-relay) | - | remote-delegation, local-first, runtime-boundary | 极简受信局域网调用边界，将一个已有本地 Agent 或自动化暴露为带密钥、可机器调用的能力。 |
 
 <a id="context-working-state-engineering"></a>
 ### Context & Working-State Engineering

--- a/data/projects.yaml
+++ b/data/projects.yaml
@@ -4771,3 +4771,16 @@ entries:
   updated_at: '2025-01-01'
   license: n/a
   why_included: High-signal practitioner framing for harness-first implementation.
+- name: OpenAgentRelay
+  repo_url: https://github.com/ShakespeareLabs/open-agent-relay
+  category: Harness Architecture & Orchestration
+  summary_en: Minimal trusted-LAN boundary that exposes one existing local agent or automation as a keyed, machine-callable capability.
+  summary_zh: 极简受信局域网调用边界，将一个已有本地 Agent 或自动化暴露为带密钥、可机器调用的能力。
+  tags:
+  - remote-delegation
+  - local-first
+  - runtime-boundary
+  stars_snapshot: 0
+  updated_at: '2026-07-14'
+  license: Apache-2.0
+  why_included: Provides an inspectable delegation boundary with target-name verification, bounded conversations, JSON output, explicit exit codes, and local retention of source, prompts, dependencies, and credentials.

--- a/reports/verification/2026-07-14.md
+++ b/reports/verification/2026-07-14.md
@@ -1,0 +1,67 @@
+# Verification Report
+
+- Generated at: `2026-07-14T08:37:36.570964+00:00`
+- Total entries: `339`
+- GitHub entries: `312` (92.0%)
+- GitHub in project categories (excluding `Essential Readings & Ecosystem Maps`): `307/307` (100.0%)
+- Categories: `9`
+- URL checks: `340` total, `340` reachable, `0` broken
+
+## Category Counts
+
+| Category | Entries |
+| --- | ---: |
+| Harness Architecture & Orchestration | 58 |
+| Context & Working-State Engineering | 24 |
+| Execution Substrates & Sandboxing | 27 |
+| Protocols, Tool Interfaces & Agent Contracts | 41 |
+| Evaluation Harnesses & Benchmarks | 29 |
+| Observability & Reliability Operations | 20 |
+| Guardrails, Security & Governance | 26 |
+| Reference Harness Implementations | 82 |
+| Essential Readings & Ecosystem Maps | 32 |
+
+## Structural Errors
+
+- stale github entries (>12 months): 1
+
+## Warnings
+
+- None
+
+## Broken URLs
+
+- None
+
+## Reachable URL Sample
+
+- `HEAD 200` https://blog.langchain.com/agent-frameworks-runtimes-and-harnesses-oh-my/
+- `HEAD 200` https://blog.langchain.com/evaluating-deep-agents-our-learnings/
+- `HEAD 200` https://blog.langchain.com/improving-deep-agents-with-harness-engineering/
+- `HEAD 200` https://blog.langchain.com/the-anatomy-of-an-agent-harness/
+- `HEAD 200` https://code.claude.com/docs/en/agent-sdk/overview
+- `HEAD 200` https://cognition.ai/blog/what-we-learned-building-cloud-agents
+- `HEAD 200` https://developers.openai.com/blog/eval-skills
+- `HEAD 200` https://github.com/1jehuang/jcode
+- `HEAD 200` https://github.com/21st-dev/1code
+- `HEAD 200` https://github.com/2FastLabs/agent-squad
+- `HEAD 200` https://github.com/AVIDS2/memorix
+- `HEAD 200` https://github.com/AgentOps-AI/agentops
+- `HEAD 200` https://github.com/Agenta-AI/agenta
+- `HEAD 200` https://github.com/Aider-AI/aider
+- `HEAD 200` https://github.com/AndyMik90/Aperant
+- `HEAD 200` https://github.com/Arize-ai/openinference
+- `HEAD 200` https://github.com/Arize-ai/phoenix
+- `HEAD 200` https://github.com/Atmosphere/atmosphere
+- `HEAD 200` https://github.com/BerriAI/litellm
+- `HEAD 200` https://github.com/BloopAI/vibe-kanban
+- `HEAD 200` https://github.com/BuilderIO/skills
+- `HEAD 200` https://github.com/Chachamaru127/claude-code-harness
+- `HEAD 200` https://github.com/Chorus-AIDLC/Chorus
+- `HEAD 200` https://github.com/ChromeDevTools/chrome-devtools-mcp
+- `HEAD 200` https://github.com/ComposioHQ/agent-orchestrator
+- `HEAD 200` https://github.com/DevAgentForge/Open-Claude-Cowork
+- `HEAD 200` https://github.com/EleutherAI/lm-evaluation-harness
+- `HEAD 200` https://github.com/EverMind-AI/EverOS
+- `HEAD 200` https://github.com/EveryInc/compound-engineering-plugin
+- `HEAD 200` https://github.com/FoundationAgents/OpenManus


### PR DESCRIPTION
Adds OpenAgentRelay to the data-driven Harness Architecture & Orchestration catalog.

The entry focuses on its inspectable delegation boundary: one existing local agent or automation per request, keyed trusted-LAN access, target verification, bounded conversations, JSON output, explicit exit codes, and local retention of source and credentials.

Validation:
- Both English and Chinese READMEs were regenerated from data/projects.yaml.
- Full URL verification reached 340/340 links.
- The verifier still reports one pre-existing GitHub entry older than 12 months; this PR does not change that unrelated catalog item.