### PR TITLE
Add Harness Engineering for Language Agents (CAR) to Essential Readings

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 A curated, implementation-first list of **agent harness engineering** resources, with GitHub projects as the primary focus.
 
-- Total entries: **338**
-- GitHub entries: **311 (92.0%)**
+- Total entries: **339**
+- GitHub entries: **311 (91.7%)**
 - GitHub in project categories (excluding readings): **306/306 (100.0%)**
 - Categories: **9**
 - Last verified: **2026-06-21**
@@ -54,7 +54,7 @@ A curated, implementation-first list of **agent harness engineering** resources,
 | Observability & Reliability Operations | 20 |
 | Guardrails, Security & Governance | 26 |
 | Reference Harness Implementations | 82 |
-| Essential Readings & Ecosystem Maps | 32 |
+| Essential Readings & Ecosystem Maps | 33 |
 
 ## Catalog
 
@@ -441,6 +441,7 @@ Notes:
 | Harness design for long-running application development | [Reference](https://www.anthropic.com/engineering/harness-design-long-running-apps) | - | reading, app-dev, anthropic | Follow-up article on improving long-running app generation through harness structure. |
 | Harness Engineering (Martin Fowler) | [Reference](https://martinfowler.com/articles/exploring-gen-ai/harness-engineering.html) | - | reading, architecture, fowler | Architectural perspective on harness engineering and entropy control. |
 | Harness engineering (OpenAI) | [Reference](https://openai.com/index/harness-engineering/) | - | reading, methodology, openai | Field report on building reliable agent-first software via harness constraints and verification. |
+| Harness Engineering for Language Agents: The Harness Layer as Control, Agency, and Runtime | [Reference](https://sciety.org/articles/activity/10.20944/preprints202603.1756.v2) | - | reading, research, taxonomy | Position paper decomposing the harness layer into control, agency, and runtime (CAR); audits 63 harness-relevant works and proposes HarnessCard for structured harness reporting. |
 | How we built our multi-agent research system | [Reference](https://www.anthropic.com/engineering/multi-agent-research-system) | - | reading, anthropic, multi-agent | Anthropic architecture write-up on role separation and coordination in multi-agent systems. |
 | Improving Deep Agents with harness engineering | [Reference](https://blog.langchain.com/improving-deep-agents-with-harness-engineering/) | - | reading, langchain, harness | Evidence that harness improvements alone can move benchmark performance. |
 | Making Claude Code more secure and autonomous with sandboxing | [Reference](https://www.anthropic.com/engineering/claude-code-sandboxing) | - | reading, anthropic, sandboxing | How Anthropic uses sandbox boundaries to raise agent autonomy without giving up security controls. |

--- a/README_zh.md
+++ b/README_zh.md
@@ -2,8 +2,8 @@
 
 一个面向 **Agent Harness Engineering** 的工程实践清单，优先收录可直接落地的 GitHub 项目。
 
-- 当前条目数: **338**
-- GitHub 条目: **311 (92.0%)**
+- 当前条目数: **339**
+- GitHub 条目: **311 (91.7%)**
 - 项目分类 GitHub 占比（不含阅读类）: **306/306 (100.0%)**
 - 分类数量: **9**
 - 最近核对日期: **2026-06-21**
@@ -54,7 +54,7 @@
 | Observability & Reliability Operations | 20 |
 | Guardrails, Security & Governance | 26 |
 | Reference Harness Implementations | 82 |
-| Essential Readings & Ecosystem Maps | 32 |
+| Essential Readings & Ecosystem Maps | 33 |
 
 ## 项目清单
 
@@ -441,6 +441,7 @@
 | Harness design for long-running application development | [Reference](https://www.anthropic.com/engineering/harness-design-long-running-apps) | - | reading, app-dev, anthropic | 关于通过 harness 结构改进长任务应用生成的后续文章。 |
 | Harness Engineering (Martin Fowler) | [Reference](https://martinfowler.com/articles/exploring-gen-ai/harness-engineering.html) | - | reading, architecture, fowler | 从架构视角讨论 harness engineering 与系统熵控制。 |
 | Harness engineering (OpenAI) | [Reference](https://openai.com/index/harness-engineering/) | - | reading, methodology, openai | 关于如何通过约束与验证构建可靠 agent-first 软件的实践报告。 |
+| Harness Engineering for Language Agents: The Harness Layer as Control, Agency, and Runtime | [Reference](https://sciety.org/articles/activity/10.20944/preprints202603.1756.v2) | - | reading, research, taxonomy | 将 harness 层解构为控制、代理与运行时（CAR）的立场论文；梳理 63 项相关工作，并提出用于结构化披露 harness 配置的 HarnessCard。 |
 | How we built our multi-agent research system | [Reference](https://www.anthropic.com/engineering/multi-agent-research-system) | - | reading, anthropic, multi-agent | Anthropic 对多代理系统中角色分工与协同机制的架构复盘。 |
 | Improving Deep Agents with harness engineering | [Reference](https://blog.langchain.com/improving-deep-agents-with-harness-engineering/) | - | reading, langchain, harness | 说明仅通过 harness 改进也能显著提升基准表现。 |
 | Making Claude Code more secure and autonomous with sandboxing | [Reference](https://www.anthropic.com/engineering/claude-code-sandboxing) | - | reading, anthropic, sandboxing | 讲解 Anthropic 如何借助沙箱边界在不放松安全控制的前提下提升代理自治性。 |

--- a/data/projects.yaml
+++ b/data/projects.yaml
@@ -4598,6 +4598,19 @@ entries:
   updated_at: '2026-01-01'
   license: n/a
   why_included: High-signal methodology reference directly focused on harness engineering.
+- name: 'Harness Engineering for Language Agents: The Harness Layer as Control, Agency, and Runtime'
+  repo_url: https://sciety.org/articles/activity/10.20944/preprints202603.1756.v2
+  category: Essential Readings & Ecosystem Maps
+  summary_en: Position paper decomposing the harness layer into control, agency, and runtime (CAR); audits 63 harness-relevant works and proposes HarnessCard for structured harness reporting.
+  summary_zh: 将 harness 层解构为控制、代理与运行时（CAR）的立场论文；梳理 63 项相关工作，并提出用于结构化披露 harness 配置的 HarnessCard。
+  tags:
+  - reading
+  - research
+  - taxonomy
+  stars_snapshot: 0
+  updated_at: '2026-04-23'
+  license: n/a
+  why_included: Academic framing of the harness layer as a research object, complementing the practitioner readings with a CAR taxonomy and a reporting artifact.
 - name: How we built our multi-agent research system
   repo_url: https://www.anthropic.com/engineering/multi-agent-research-system
   category: Essential Readings & Ecosystem Maps

--- a/reports/verification/2026-07-16.md
+++ b/reports/verification/2026-07-16.md
@@ -1,0 +1,67 @@
+# Verification Report
+
+- Generated at: `2026-07-15T17:55:37.789670+00:00`
+- Total entries: `339`
+- GitHub entries: `311` (91.7%)
+- GitHub in project categories (excluding `Essential Readings & Ecosystem Maps`): `306/306` (100.0%)
+- Categories: `9`
+- URL checks: `340` total, `340` reachable, `0` broken
+
+## Category Counts
+
+| Category | Entries |
+| --- | ---: |
+| Harness Architecture & Orchestration | 57 |
+| Context & Working-State Engineering | 24 |
+| Execution Substrates & Sandboxing | 27 |
+| Protocols, Tool Interfaces & Agent Contracts | 41 |
+| Evaluation Harnesses & Benchmarks | 29 |
+| Observability & Reliability Operations | 20 |
+| Guardrails, Security & Governance | 26 |
+| Reference Harness Implementations | 82 |
+| Essential Readings & Ecosystem Maps | 33 |
+
+## Structural Errors
+
+- stale github entries (>12 months): 1
+
+## Warnings
+
+- None
+
+## Broken URLs
+
+- None
+
+## Reachable URL Sample
+
+- `HEAD 200` https://blog.langchain.com/agent-frameworks-runtimes-and-harnesses-oh-my/
+- `HEAD 200` https://blog.langchain.com/evaluating-deep-agents-our-learnings/
+- `HEAD 200` https://blog.langchain.com/improving-deep-agents-with-harness-engineering/
+- `HEAD 200` https://blog.langchain.com/the-anatomy-of-an-agent-harness/
+- `HEAD 200` https://code.claude.com/docs/en/agent-sdk/overview
+- `HEAD 200` https://cognition.ai/blog/what-we-learned-building-cloud-agents
+- `HEAD 200` https://developers.openai.com/blog/eval-skills
+- `HEAD 200` https://github.com/1jehuang/jcode
+- `HEAD 200` https://github.com/21st-dev/1code
+- `HEAD 200` https://github.com/2FastLabs/agent-squad
+- `HEAD 200` https://github.com/AVIDS2/memorix
+- `HEAD 200` https://github.com/AgentOps-AI/agentops
+- `HEAD 200` https://github.com/Agenta-AI/agenta
+- `HEAD 200` https://github.com/Aider-AI/aider
+- `HEAD 200` https://github.com/AndyMik90/Aperant
+- `HEAD 200` https://github.com/Arize-ai/openinference
+- `HEAD 200` https://github.com/Arize-ai/phoenix
+- `HEAD 200` https://github.com/Atmosphere/atmosphere
+- `HEAD 200` https://github.com/BerriAI/litellm
+- `HEAD 200` https://github.com/BloopAI/vibe-kanban
+- `HEAD 200` https://github.com/BuilderIO/skills
+- `HEAD 200` https://github.com/Chachamaru127/claude-code-harness
+- `HEAD 200` https://github.com/Chorus-AIDLC/Chorus
+- `HEAD 200` https://github.com/ChromeDevTools/chrome-devtools-mcp
+- `HEAD 200` https://github.com/ComposioHQ/agent-orchestrator
+- `HEAD 200` https://github.com/DevAgentForge/Open-Claude-Cowork
+- `HEAD 200` https://github.com/EleutherAI/lm-evaluation-harness
+- `HEAD 200` https://github.com/EverMind-AI/EverOS
+- `HEAD 200` https://github.com/EveryInc/compound-engineering-plugin
+- `HEAD 200` https://github.com/FoundationAgents/OpenManus


### PR DESCRIPTION
Adds **"Harness Engineering for Language Agents: The Harness Layer as Control, Agency, and Runtime"** (He et al., Preprints 2026) to **Essential Readings & Ecosystem Maps**.

A position paper that treats the harness layer as a research object: proposes the **control–agency–runtime (CAR)** decomposition, audits 63 harness-relevant works across academia and public engineering notes, and introduces **HarnessCard** for structured harness reporting — an academic complement to the practitioner readings in this section.

Followed the maintenance workflow: edited `data/projects.yaml` (alphabetical, bilingual summaries, tags), ran `render_readme.py` (README.md + README_zh.md regenerated) and `verify_catalog.py` (report included; **0 broken URLs** — the one remaining stale-github flag is a pre-existing entry).

Note on the link: the canonical page is https://www.preprints.org/manuscript/202603.1756/v2 (DOI 10.20944/preprints202603.1756), but preprints.org returns HTTP 403 to automated checkers (incl. `verify_catalog.py`), so the entry links the paper's Sciety activity page, which resolves cleanly and carries the DOI. Happy to switch to the preprints URL if you prefer to allowlist it.

Disclosure: I am an author.