### PR TITLE
Add Garcon to Harness Architecture & Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 A curated, implementation-first list of **agent harness engineering** resources, with GitHub projects as the primary focus.
 
-- Total entries: **338**
-- GitHub entries: **311 (92.0%)**
-- GitHub in project categories (excluding readings): **306/306 (100.0%)**
+- Total entries: **339**
+- GitHub entries: **312 (92.0%)**
+- GitHub in project categories (excluding readings): **307/307 (100.0%)**
 - Categories: **9**
-- Last verified: **2026-06-21**
+- Last verified: **2026-07-22**
 - Language: [English](./README.md) | [中文](./README_zh.md)
 
 <a id="featured-harness-blogs"></a>
@@ -46,7 +46,7 @@ A curated, implementation-first list of **agent harness engineering** resources,
 
 | Category | Entries |
 | --- | ---: |
-| Harness Architecture & Orchestration | 57 |
+| Harness Architecture & Orchestration | 58 |
 | Context & Working-State Engineering | 24 |
 | Execution Substrates & Sandboxing | 27 |
 | Protocols, Tool Interfaces & Agent Contracts | 41 |
@@ -125,6 +125,7 @@ Notes:
 | Water | [GitHub](https://github.com/manthanguptaa/water) | [![star](https://img.shields.io/badge/star-292-f4b400?style=flat-square)](https://github.com/manthanguptaa/water) | python, framework, approval-gates | Python agent harness framework for orchestration, resilience, observability, guardrails, approval gates, sandboxing, and deployment. |
 | OmniCoreAgent | [GitHub](https://github.com/omnirexflora-labs/omnicoreagent) | [![star](https://img.shields.io/badge/star-243-f4b400?style=flat-square)](https://github.com/omnirexflora-labs/omnicoreagent) | python, mcp, serving | Python production harness with model loop, tools, MCP, memory, workspace files, guardrails, events, subagents, background tasks, and REST/SSE serving. |
 | hankweave | [GitHub](https://github.com/SouthBridgeAI/hankweave-runtime) | [![star](https://img.shields.io/badge/star-129-f4b400?style=flat-square)](https://github.com/SouthBridgeAI/hankweave-runtime) | long-horizon, runtime, checkpoints | Headless-first long-horizon runtime that orchestrates existing agent harnesses with sentinels, loops, checkpoints, and event journals. |
+| Garcon | [GitHub](https://github.com/cfal/garcon) | [![star](https://img.shields.io/badge/star-40-f4b400?style=flat-square)](https://github.com/cfal/garcon) | control-plane, sessions, code-review | Self-hosted browser and mobile workspace for running, steering, and reviewing parallel coding-agent sessions with integrated terminal, file, diff, Git, and pull-request workflows. |
 
 <a id="context-working-state-engineering"></a>
 ### Context & Working-State Engineering

--- a/README_zh.md
+++ b/README_zh.md
@@ -2,11 +2,11 @@
 
 一个面向 **Agent Harness Engineering** 的工程实践清单，优先收录可直接落地的 GitHub 项目。
 
-- 当前条目数: **338**
-- GitHub 条目: **311 (92.0%)**
-- 项目分类 GitHub 占比（不含阅读类）: **306/306 (100.0%)**
+- 当前条目数: **339**
+- GitHub 条目: **312 (92.0%)**
+- 项目分类 GitHub 占比（不含阅读类）: **307/307 (100.0%)**
 - 分类数量: **9**
-- 最近核对日期: **2026-06-21**
+- 最近核对日期: **2026-07-22**
 - 语言: [English](./README.md) | [中文](./README_zh.md)
 
 <a id="featured-harness-blogs"></a>
@@ -46,7 +46,7 @@
 
 | 分类 | 条目数 |
 | --- | ---: |
-| Harness Architecture & Orchestration | 57 |
+| Harness Architecture & Orchestration | 58 |
 | Context & Working-State Engineering | 24 |
 | Execution Substrates & Sandboxing | 27 |
 | Protocols, Tool Interfaces & Agent Contracts | 41 |
@@ -125,6 +125,7 @@
 | Water | [GitHub](https://github.com/manthanguptaa/water) | [![star](https://img.shields.io/badge/star-292-f4b400?style=flat-square)](https://github.com/manthanguptaa/water) | python, framework, approval-gates | Python agent harness 框架，覆盖编排、韧性、可观测性、护栏、审批门禁、沙箱与部署。 |
 | OmniCoreAgent | [GitHub](https://github.com/omnirexflora-labs/omnicoreagent) | [![star](https://img.shields.io/badge/star-243-f4b400?style=flat-square)](https://github.com/omnirexflora-labs/omnicoreagent) | python, mcp, serving | Python 生产级 harness，包含模型循环、工具、MCP、记忆、工作区文件、护栏、事件、子代理、后台任务与 REST/SSE 服务。 |
 | hankweave | [GitHub](https://github.com/SouthBridgeAI/hankweave-runtime) | [![star](https://img.shields.io/badge/star-129-f4b400?style=flat-square)](https://github.com/SouthBridgeAI/hankweave-runtime) | long-horizon, runtime, checkpoints | 面向长任务的无界面运行时，可编排现有 agent harness，并提供 sentinels、循环、检查点与事件日志。 |
+| Garcon | [GitHub](https://github.com/cfal/garcon) | [![star](https://img.shields.io/badge/star-40-f4b400?style=flat-square)](https://github.com/cfal/garcon) | control-plane, sessions, code-review | 自托管的浏览器与移动端编码代理工作区，可并行运行和实时引导 Claude Code、Codex、Cursor Agent、OpenCode、Amp、Droid 与 Pi 会话，并集成终端、文件编辑、差异审查及 Git/PR 工作流。 |
 
 <a id="context-working-state-engineering"></a>
 ### Context & Working-State Engineering

--- a/data/projects.yaml
+++ b/data/projects.yaml
@@ -1,7 +1,7 @@
 catalog:
   title_en: Awesome Agent Harness
   title_zh: Awesome Agent Harness
-  last_verified: '2026-06-21'
+  last_verified: '2026-07-22'
   description_en: Curated implementation-first list for agent harness engineering.
   description_zh: 面向 Agent Harness Engineering 的工程实践清单。
 categories:
@@ -854,6 +854,21 @@ entries:
   updated_at: '2026-06-10'
   license: Apache-2.0
   why_included: Strong example of a harness runtime built around repairability, rollback, and controlled long-running execution.
+- name: Garcon
+  repo_url: https://github.com/cfal/garcon
+  category: Harness Architecture & Orchestration
+  summary_en: Self-hosted browser and mobile workspace for running, steering, and reviewing parallel coding-agent sessions with
+    integrated terminal, file, diff, Git, and pull-request workflows.
+  summary_zh: 自托管的浏览器与移动端编码代理工作区，可并行运行和实时引导 Claude Code、Codex、Cursor Agent、OpenCode、Amp、Droid 与 Pi 会话，并集成终端、文件编辑、差异审查及 Git/PR 工作流。
+  tags:
+  - control-plane
+  - sessions
+  - code-review
+  stars_snapshot: 40
+  updated_at: '2026-07-22'
+  license: GPL-3.0
+  why_included: README documents native multi-agent session orchestration, live steering and approvals, integrated terminal/file/diff/Git/PR
+    workflows, mobile access, scheduling, and cross-agent session transfer.
 - name: claude-mem
   repo_url: https://github.com/thedotmack/claude-mem
   category: Context & Working-State Engineering

--- a/reports/verification/2026-07-22.md
+++ b/reports/verification/2026-07-22.md
@@ -1,0 +1,68 @@
+# Verification Report
+
+- Generated at: `2026-07-22T19:33:34.817635+00:00`
+- Total entries: `339`
+- GitHub entries: `312` (92.0%)
+- GitHub in project categories (excluding `Essential Readings & Ecosystem Maps`): `307/307` (100.0%)
+- Categories: `9`
+- URL checks: `340` total, `339` reachable, `1` broken
+
+## Category Counts
+
+| Category | Entries |
+| --- | ---: |
+| Harness Architecture & Orchestration | 58 |
+| Context & Working-State Engineering | 24 |
+| Execution Substrates & Sandboxing | 27 |
+| Protocols, Tool Interfaces & Agent Contracts | 41 |
+| Evaluation Harnesses & Benchmarks | 29 |
+| Observability & Reliability Operations | 20 |
+| Guardrails, Security & Governance | 26 |
+| Reference Harness Implementations | 82 |
+| Essential Readings & Ecosystem Maps | 32 |
+
+## Structural Errors
+
+- stale github entries (>12 months): 1
+- broken urls: 1
+
+## Warnings
+
+- None
+
+## Broken URLs
+
+- `HTTP 403` https://openreview.net/pdf?id=eONq7FdiHa
+
+## Reachable URL Sample
+
+- `HEAD 200` https://blog.langchain.com/agent-frameworks-runtimes-and-harnesses-oh-my/
+- `HEAD 200` https://blog.langchain.com/evaluating-deep-agents-our-learnings/
+- `HEAD 200` https://blog.langchain.com/improving-deep-agents-with-harness-engineering/
+- `HEAD 200` https://blog.langchain.com/the-anatomy-of-an-agent-harness/
+- `HEAD 200` https://code.claude.com/docs/en/agent-sdk/overview
+- `HEAD 200` https://cognition.ai/blog/what-we-learned-building-cloud-agents
+- `HEAD 200` https://developers.openai.com/blog/eval-skills
+- `HEAD 200` https://github.com/1jehuang/jcode
+- `HEAD 200` https://github.com/21st-dev/1code
+- `HEAD 200` https://github.com/2FastLabs/agent-squad
+- `HEAD 200` https://github.com/AVIDS2/memorix
+- `HEAD 200` https://github.com/AgentOps-AI/agentops
+- `HEAD 200` https://github.com/Agenta-AI/agenta
+- `HEAD 200` https://github.com/Aider-AI/aider
+- `HEAD 200` https://github.com/AndyMik90/Aperant
+- `HEAD 200` https://github.com/Arize-ai/openinference
+- `HEAD 200` https://github.com/Arize-ai/phoenix
+- `HEAD 200` https://github.com/Atmosphere/atmosphere
+- `HEAD 200` https://github.com/BerriAI/litellm
+- `HEAD 200` https://github.com/BloopAI/vibe-kanban
+- `HEAD 200` https://github.com/BuilderIO/skills
+- `HEAD 200` https://github.com/Chachamaru127/claude-code-harness
+- `HEAD 200` https://github.com/Chorus-AIDLC/Chorus
+- `HEAD 200` https://github.com/ChromeDevTools/chrome-devtools-mcp
+- `HEAD 200` https://github.com/ComposioHQ/agent-orchestrator
+- `HEAD 200` https://github.com/DevAgentForge/Open-Claude-Cowork
+- `HEAD 200` https://github.com/EleutherAI/lm-evaluation-harness
+- `HEAD 200` https://github.com/EverMind-AI/EverOS
+- `HEAD 200` https://github.com/EveryInc/compound-engineering-plugin
+- `HEAD 200` https://github.com/FoundationAgents/OpenManus


### PR DESCRIPTION
## Summary

Adds Garcon to Harness Architecture & Orchestration through the structured catalog, then regenerates the English and Chinese READMEs.

Garcon is a GPL-3.0 self-hosted browser and mobile control plane for parallel coding-agent sessions. It supports Claude Code, Codex, Cursor Agent, OpenCode, Amp, Droid, and Pi with live steering, approvals, terminal/files/diffs, Git and pull-request workflows, scheduling, and cross-agent transfers.

## Validation

- Ran the GitHub metadata sync to confirm the repository metadata.
- Ran `python3 scripts/render_readme.py`.
- Ran `python3 scripts/verify_catalog.py`.
- Added the generated verification report; Garcon's URL is reachable. The report retains one unrelated existing OpenReview PDF response of HTTP 403.

Disclosure: I maintain Garcon.
