### PR TITLE
Add TierDecay to Harness Architecture & Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A curated, implementation-first list of **agent harness engineering** resources, with GitHub projects as the primary focus.
 
-- Total entries: **338**
-- GitHub entries: **311 (92.0%)**
-- GitHub in project categories (excluding readings): **306/306 (100.0%)**
+- Total entries: **339**
+- GitHub entries: **312 (92.0%)**
+- GitHub in project categories (excluding readings): **307/307 (100.0%)**
 - Categories: **9**
 - Last verified: **2026-06-21**
 - Language: [English](./README.md) | [中文](./README_zh.md)
@@ -46,7 +46,7 @@ A curated, implementation-first list of **agent harness engineering** resources,
 
 | Category | Entries |
 | --- | ---: |
-| Harness Architecture & Orchestration | 57 |
+| Harness Architecture & Orchestration | 58 |
 | Context & Working-State Engineering | 24 |
 | Execution Substrates & Sandboxing | 27 |
 | Protocols, Tool Interfaces & Agent Contracts | 41 |
@@ -125,6 +125,7 @@ Notes:
 | Water | [GitHub](https://github.com/manthanguptaa/water) | [![star](https://img.shields.io/badge/star-292-f4b400?style=flat-square)](https://github.com/manthanguptaa/water) | python, framework, approval-gates | Python agent harness framework for orchestration, resilience, observability, guardrails, approval gates, sandboxing, and deployment. |
 | OmniCoreAgent | [GitHub](https://github.com/omnirexflora-labs/omnicoreagent) | [![star](https://img.shields.io/badge/star-243-f4b400?style=flat-square)](https://github.com/omnirexflora-labs/omnicoreagent) | python, mcp, serving | Python production harness with model loop, tools, MCP, memory, workspace files, guardrails, events, subagents, background tasks, and REST/SSE serving. |
 | hankweave | [GitHub](https://github.com/SouthBridgeAI/hankweave-runtime) | [![star](https://img.shields.io/badge/star-129-f4b400?style=flat-square)](https://github.com/SouthBridgeAI/hankweave-runtime) | long-horizon, runtime, checkpoints | Headless-first long-horizon runtime that orchestrates existing agent harnesses with sentinels, loops, checkpoints, and event journals. |
+| TierDecay | [GitHub](https://github.com/alebgl77/tierdecay) | [![star](https://img.shields.io/badge/star-1-f4b400?style=flat-square)](https://github.com/alebgl77/tierdecay) | routing, workflow, cross-agent | Self-distilling tier router that solves each task class once at an expensive model tier, distills it into a low-tier playbook entry, and decays the class's default tier down via a ledger of predicted-vs-executed tiers. |
 
 <a id="context-working-state-engineering"></a>
 ### Context & Working-State Engineering

--- a/README_zh.md
+++ b/README_zh.md
@@ -2,9 +2,9 @@
 
 一个面向 **Agent Harness Engineering** 的工程实践清单，优先收录可直接落地的 GitHub 项目。
 
-- 当前条目数: **338**
-- GitHub 条目: **311 (92.0%)**
-- 项目分类 GitHub 占比（不含阅读类）: **306/306 (100.0%)**
+- 当前条目数: **339**
+- GitHub 条目: **312 (92.0%)**
+- 项目分类 GitHub 占比（不含阅读类）: **307/307 (100.0%)**
 - 分类数量: **9**
 - 最近核对日期: **2026-06-21**
 - 语言: [English](./README.md) | [中文](./README_zh.md)
@@ -46,7 +46,7 @@
 
 | 分类 | 条目数 |
 | --- | ---: |
-| Harness Architecture & Orchestration | 57 |
+| Harness Architecture & Orchestration | 58 |
 | Context & Working-State Engineering | 24 |
 | Execution Substrates & Sandboxing | 27 |
 | Protocols, Tool Interfaces & Agent Contracts | 41 |
@@ -125,6 +125,7 @@
 | Water | [GitHub](https://github.com/manthanguptaa/water) | [![star](https://img.shields.io/badge/star-292-f4b400?style=flat-square)](https://github.com/manthanguptaa/water) | python, framework, approval-gates | Python agent harness 框架，覆盖编排、韧性、可观测性、护栏、审批门禁、沙箱与部署。 |
 | OmniCoreAgent | [GitHub](https://github.com/omnirexflora-labs/omnicoreagent) | [![star](https://img.shields.io/badge/star-243-f4b400?style=flat-square)](https://github.com/omnirexflora-labs/omnicoreagent) | python, mcp, serving | Python 生产级 harness，包含模型循环、工具、MCP、记忆、工作区文件、护栏、事件、子代理、后台任务与 REST/SSE 服务。 |
 | hankweave | [GitHub](https://github.com/SouthBridgeAI/hankweave-runtime) | [![star](https://img.shields.io/badge/star-129-f4b400?style=flat-square)](https://github.com/SouthBridgeAI/hankweave-runtime) | long-horizon, runtime, checkpoints | 面向长任务的无界面运行时，可编排现有 agent harness，并提供 sentinels、循环、检查点与事件日志。 |
+| TierDecay | [GitHub](https://github.com/alebgl77/tierdecay) | [![star](https://img.shields.io/badge/star-1-f4b400?style=flat-square)](https://github.com/alebgl77/tierdecay) | routing, workflow, cross-agent | 自蒸馏分层路由：将每类任务在高价模型层解决一次，蒸馏为低层 playbook 条目，并依据预测层与实际执行层的账本，逐步下调该类任务的默认层级。 |
 
 <a id="context-working-state-engineering"></a>
 ### Context & Working-State Engineering

--- a/data/projects.yaml
+++ b/data/projects.yaml
@@ -57,6 +57,19 @@ entries:
   license: MIT
   why_included: README documents install paths for Claude Code, Codex, Codex App, Gemini CLI, OpenCode, Cursor, and Copilot
     CLI plus mandatory planning, worktree, TDD, review, and subagent workflows.
+- name: TierDecay
+  repo_url: https://github.com/alebgl77/tierdecay
+  category: Harness Architecture & Orchestration
+  summary_en: Self-distilling tier router that solves each task class once at an expensive model tier, distills it into a low-tier playbook entry, and decays the class's default tier down via a ledger of predicted-vs-executed tiers.
+  summary_zh: 自蒸馏分层路由：将每类任务在高价模型层解决一次，蒸馏为低层 playbook 条目，并依据预测层与实际执行层的账本，逐步下调该类任务的默认层级。
+  tags:
+  - routing
+  - workflow
+  - cross-agent
+  stars_snapshot: 1
+  updated_at: '2026-07-23'
+  license: MIT
+  why_included: Ships a native Claude Code pipeline (scout/executor/heavy-executor/oracle subagents, skills, a PreToolUse integrity hook, a routing ledger) plus AGENTS.md, Cursor, Gemini CLI, Aider, Cline, Goose, and Windsurf adapters that decay recurring task classes to cheaper model tiers.
 - name: ECC
   repo_url: https://github.com/affaan-m/ECC
   category: Harness Architecture & Orchestration


### PR DESCRIPTION
Adds **TierDecay** to `Harness Architecture & Orchestration` — same category as Superpowers / ECC.

- **Repo:** https://github.com/alebgl77/tierdecay (MIT)
- **What it is:** a self-distilling tier router / harness for CLI coding agents. It solves each recurring task class once at an expensive model tier, distills the decision into a ≤15-line playbook entry, then probes and decays that class's default tier down (T3→T2→T1) via a ledger of predicted-vs-executed tiers. Ships a native Claude Code pipeline (scout/executor/heavy-executor/oracle subagents, skills, a `PreToolUse` integrity hook, a routing ledger) plus AGENTS.md, Cursor, Gemini CLI, Aider, Cline, Goose, and Windsurf adapters.

**Process followed:** edited `data/projects.yaml` (single entry, EN + ZH summaries, tags, `why_included`), then regenerated `README.md` + `README_zh.md` with `python scripts/render_readme.py`. Diff is the one entry plus the auto-updated counts.

Note: `verify_catalog.py` reports two **pre-existing** issues unrelated to this entry — a `HTTP 403` on `https://openreview.net/pdf?id=eONq7FdiHa` (that host blocks HEAD requests) and one GitHub entry stale >12 months. TierDecay itself passes (reachable, dated today). I left those untouched to keep this PR scoped; happy to open a separate PR if you'd like them addressed. I did not commit a re-verification report for the same reason.