### PR TITLE
Add AOHP to Reference Harness Implementations

### DIFF
--- a/data/projects.yaml
+++ b/data/projects.yaml
@@ -4771,3 +4771,17 @@ entries:
   updated_at: '2025-01-01'
   license: n/a
   why_included: High-signal practitioner framing for harness-first implementation.
+
+- name: AOHP
+  repo_url: https://github.com/aohp-os/aohp
+  category: Reference Harness Implementations
+  summary_en: OS-level agent harness to enable personalized, efficient and secure interaction. And let the OS proactively adapt to its user via agentic AI.
+  summary_zh: OS 级 Agent Harness，面向个性化、高效且安全的交互，让操作系统借助 agentic AI 主动适应用户。
+  tags:
+  - agent-os
+  - personalization
+  - security
+  stars_snapshot: 139
+  updated_at: '2026-07-25'
+  license: Apache-2.0
+  why_included: An OS-level agent harness that redesigns system and framework components to enable personalized, efficient and secure interaction, letting the OS proactively adapt to its user via agentic AI.


### PR DESCRIPTION
## Summary
- Add **AOHP** under Reference Harness Implementations via `data/projects.yaml`.
- AOHP is an OS-level agent harness that lets the OS proactively adapt to its user via agentic AI, enabling personalized, efficient and secure interaction.

## Notes
- Entry added in `data/projects.yaml` (source of truth per CONTRIBUTING).
- If README regeneration is required on your side, please run the repo sync/render scripts after merge.

## Paper
https://arxiv.org/abs/2606.23449

cc @Picrew