### PR TITLE
Add Coder Eval to Evaluation Harnesses & Benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A curated, implementation-first list of **agent harness engineering** resources, with GitHub projects as the primary focus.
 
-- Total entries: **338**
-- GitHub entries: **311 (92.0%)**
-- GitHub in project categories (excluding readings): **306/306 (100.0%)**
+- Total entries: **339**
+- GitHub entries: **312 (92.0%)**
+- GitHub in project categories (excluding readings): **307/307 (100.0%)**
 - Categories: **9**
 - Last verified: **2026-06-21**
 - Language: [English](./README.md) | [中文](./README_zh.md)
@@ -50,7 +50,7 @@ A curated, implementation-first list of **agent harness engineering** resources,
 | Context & Working-State Engineering | 24 |
 | Execution Substrates & Sandboxing | 27 |
 | Protocols, Tool Interfaces & Agent Contracts | 41 |
-| Evaluation Harnesses & Benchmarks | 29 |
+| Evaluation Harnesses & Benchmarks | 30 |
 | Observability & Reliability Operations | 20 |
 | Guardrails, Security & Governance | 26 |
 | Reference Harness Implementations | 82 |
@@ -267,6 +267,7 @@ Notes:
 | ClawBench | [GitHub](https://github.com/TIGER-AI-Lab/ClawBench) | [![star](https://img.shields.io/badge/star-411-f4b400?style=flat-square)](https://github.com/TIGER-AI-Lab/ClawBench) | browser-agent, benchmark, recording | Browser-agent benchmark with live-site tasks, isolated containers, five-layer recording, and agentic scoring. |
 | Agent Evaluation | [GitHub](https://github.com/awslabs/agent-evaluation) | [![star](https://img.shields.io/badge/star-368-f4b400?style=flat-square)](https://github.com/awslabs/agent-evaluation) | evaluation, testing, ci | AWS framework for testing virtual agents with evaluator-driven multi-turn conversations, hooks, and CI-friendly workflows. |
 | WorkArena | [GitHub](https://github.com/ServiceNow/WorkArena) | [![star](https://img.shields.io/badge/star-256-f4b400?style=flat-square)](https://github.com/ServiceNow/WorkArena) | browser, benchmark, enterprise | Browser benchmark for practical enterprise-like knowledge work tasks. |
+| Coder Eval | [GitHub](https://github.com/UiPath/coder_eval) | [![star](https://img.shields.io/badge/star-107-f4b400?style=flat-square)](https://github.com/UiPath/coder_eval) | coding-agents, skills, ci | Sandboxed eval harness for coding agents and their skills, with declarative YAML tasks, weighted scoring, A/B experiments, and CI gating. |
 | OpenHands Benchmarks | [GitHub](https://github.com/OpenHands/benchmarks) | [![star](https://img.shields.io/badge/star-91-f4b400?style=flat-square)](https://github.com/OpenHands/benchmarks) | openhands, eval, harness | Evaluation harness and benchmark definitions for OpenHands systems. |
 | WebArena-Verified | [GitHub](https://github.com/ServiceNow/webarena-verified) | [![star](https://img.shields.io/badge/star-43-f4b400?style=flat-square)](https://github.com/ServiceNow/webarena-verified) | web-agent, benchmark, deterministic | Verified web-agent benchmark with deterministic evaluators. |
 | HarnessBench | [GitHub](https://github.com/reacher-z/HarnessBench) | [![star](https://img.shields.io/badge/star-17-f4b400?style=flat-square)](https://github.com/reacher-z/HarnessBench) | harness-comparison, browser-agent, benchmark | Benchmark for comparing agent harnesses on the same everyday web tasks with fixed models and per-harness containers. |

--- a/README_zh.md
+++ b/README_zh.md
@@ -2,9 +2,9 @@
 
 一个面向 **Agent Harness Engineering** 的工程实践清单，优先收录可直接落地的 GitHub 项目。
 
-- 当前条目数: **338**
-- GitHub 条目: **311 (92.0%)**
-- 项目分类 GitHub 占比（不含阅读类）: **306/306 (100.0%)**
+- 当前条目数: **339**
+- GitHub 条目: **312 (92.0%)**
+- 项目分类 GitHub 占比（不含阅读类）: **307/307 (100.0%)**
 - 分类数量: **9**
 - 最近核对日期: **2026-06-21**
 - 语言: [English](./README.md) | [中文](./README_zh.md)
@@ -50,7 +50,7 @@
 | Context & Working-State Engineering | 24 |
 | Execution Substrates & Sandboxing | 27 |
 | Protocols, Tool Interfaces & Agent Contracts | 41 |
-| Evaluation Harnesses & Benchmarks | 29 |
+| Evaluation Harnesses & Benchmarks | 30 |
 | Observability & Reliability Operations | 20 |
 | Guardrails, Security & Governance | 26 |
 | Reference Harness Implementations | 82 |
@@ -267,6 +267,7 @@
 | ClawBench | [GitHub](https://github.com/TIGER-AI-Lab/ClawBench) | [![star](https://img.shields.io/badge/star-411-f4b400?style=flat-square)](https://github.com/TIGER-AI-Lab/ClawBench) | browser-agent, benchmark, recording | 浏览器代理基准，覆盖真实网站任务、隔离容器、五层记录与 agentic 评分流程。 |
 | Agent Evaluation | [GitHub](https://github.com/awslabs/agent-evaluation) | [![star](https://img.shields.io/badge/star-368-f4b400?style=flat-square)](https://github.com/awslabs/agent-evaluation) | evaluation, testing, ci | AWS 的虚拟代理测试框架，支持评估器驱动的多轮对话、钩子扩展与 CI 友好工作流。 |
 | WorkArena | [GitHub](https://github.com/ServiceNow/WorkArena) | [![star](https://img.shields.io/badge/star-256-f4b400?style=flat-square)](https://github.com/ServiceNow/WorkArena) | browser, benchmark, enterprise | 面向企业知识工作任务的浏览器代理基准。 |
+| Coder Eval | [GitHub](https://github.com/UiPath/coder_eval) | [![star](https://img.shields.io/badge/star-107-f4b400?style=flat-square)](https://github.com/UiPath/coder_eval) | coding-agents, skills, ci | 面向编码代理及其技能的沙箱化评测 harness，支持声明式 YAML 任务、加权评分、A/B 实验与 CI 门禁。 |
 | OpenHands Benchmarks | [GitHub](https://github.com/OpenHands/benchmarks) | [![star](https://img.shields.io/badge/star-91-f4b400?style=flat-square)](https://github.com/OpenHands/benchmarks) | openhands, eval, harness | OpenHands 体系的评测 harness 与基准定义。 |
 | WebArena-Verified | [GitHub](https://github.com/ServiceNow/webarena-verified) | [![star](https://img.shields.io/badge/star-43-f4b400?style=flat-square)](https://github.com/ServiceNow/webarena-verified) | web-agent, benchmark, deterministic | 带确定性评测器的已验证 Web 代理基准。 |
 | HarnessBench | [GitHub](https://github.com/reacher-z/HarnessBench) | [![star](https://img.shields.io/badge/star-17-f4b400?style=flat-square)](https://github.com/reacher-z/HarnessBench) | harness-comparison, browser-agent, benchmark | 用固定模型在相同日常网页任务上比较不同 agent harness 的基准，并为每个 harness 使用独立容器。 |

--- a/data/projects.yaml
+++ b/data/projects.yaml
@@ -2504,6 +2504,21 @@ entries:
   updated_at: '2026-04-25'
   license: NOASSERTION
   why_included: Measures harness quality on realistic business workflows.
+- name: Coder Eval
+  repo_url: https://github.com/UiPath/coder_eval
+  category: Evaluation Harnesses & Benchmarks
+  summary_en: Sandboxed eval harness for coding agents and their skills, with declarative
+    YAML tasks, weighted scoring, A/B experiments, and CI gating.
+  summary_zh: 面向编码代理及其技能的沙箱化评测 harness，支持声明式 YAML 任务、加权评分、A/B 实验与 CI 门禁。
+  tags:
+  - coding-agents
+  - skills
+  - ci
+  stars_snapshot: 107
+  updated_at: '2026-07-28'
+  license: Apache-2.0
+  why_included: Harness-level eval for the tasks and skills a team ships, with skill-activation
+    precision/recall and cross-agent A/B runs.
 - name: OpenHands Benchmarks
   repo_url: https://github.com/OpenHands/benchmarks
   category: Evaluation Harnesses & Benchmarks

--- a/reports/verification/2026-07-28.md
+++ b/reports/verification/2026-07-28.md
@@ -1,0 +1,68 @@
+# Verification Report
+
+- Generated at: `2026-07-28T18:10:03.237878+00:00`
+- Total entries: `339`
+- GitHub entries: `312` (92.0%)
+- GitHub in project categories (excluding `Essential Readings & Ecosystem Maps`): `307/307` (100.0%)
+- Categories: `9`
+- URL checks: `340` total, `339` reachable, `1` broken
+
+## Category Counts
+
+| Category | Entries |
+| --- | ---: |
+| Harness Architecture & Orchestration | 57 |
+| Context & Working-State Engineering | 24 |
+| Execution Substrates & Sandboxing | 27 |
+| Protocols, Tool Interfaces & Agent Contracts | 41 |
+| Evaluation Harnesses & Benchmarks | 30 |
+| Observability & Reliability Operations | 20 |
+| Guardrails, Security & Governance | 26 |
+| Reference Harness Implementations | 82 |
+| Essential Readings & Ecosystem Maps | 32 |
+
+## Structural Errors
+
+- stale github entries (>12 months): 1
+- broken urls: 1
+
+## Warnings
+
+- None
+
+## Broken URLs
+
+- `HTTP 403` https://openreview.net/pdf?id=eONq7FdiHa
+
+## Reachable URL Sample
+
+- `HEAD 200` https://blog.langchain.com/agent-frameworks-runtimes-and-harnesses-oh-my/
+- `HEAD 200` https://blog.langchain.com/evaluating-deep-agents-our-learnings/
+- `HEAD 200` https://blog.langchain.com/improving-deep-agents-with-harness-engineering/
+- `HEAD 200` https://blog.langchain.com/the-anatomy-of-an-agent-harness/
+- `HEAD 200` https://code.claude.com/docs/en/agent-sdk/overview
+- `HEAD 200` https://cognition.ai/blog/what-we-learned-building-cloud-agents
+- `HEAD 200` https://developers.openai.com/blog/eval-skills
+- `HEAD 200` https://github.com/1jehuang/jcode
+- `HEAD 200` https://github.com/21st-dev/1code
+- `HEAD 200` https://github.com/2FastLabs/agent-squad
+- `HEAD 200` https://github.com/AVIDS2/memorix
+- `HEAD 200` https://github.com/AgentOps-AI/agentops
+- `HEAD 200` https://github.com/Agenta-AI/agenta
+- `HEAD 200` https://github.com/Aider-AI/aider
+- `HEAD 200` https://github.com/AndyMik90/Aperant
+- `HEAD 200` https://github.com/Arize-ai/openinference
+- `HEAD 200` https://github.com/Arize-ai/phoenix
+- `HEAD 200` https://github.com/Atmosphere/atmosphere
+- `HEAD 200` https://github.com/BerriAI/litellm
+- `HEAD 200` https://github.com/BloopAI/vibe-kanban
+- `HEAD 200` https://github.com/BuilderIO/skills
+- `HEAD 200` https://github.com/Chachamaru127/claude-code-harness
+- `HEAD 200` https://github.com/Chorus-AIDLC/Chorus
+- `HEAD 200` https://github.com/ChromeDevTools/chrome-devtools-mcp
+- `HEAD 200` https://github.com/ComposioHQ/agent-orchestrator
+- `HEAD 200` https://github.com/DevAgentForge/Open-Claude-Cowork
+- `HEAD 200` https://github.com/EleutherAI/lm-evaluation-harness
+- `HEAD 200` https://github.com/EverMind-AI/EverOS
+- `HEAD 200` https://github.com/EveryInc/compound-engineering-plugin
+- `HEAD 200` https://github.com/FoundationAgents/OpenManus


### PR DESCRIPTION
Adds [Coder Eval](https://github.com/UiPath/coder_eval) to **Evaluation Harnesses & Benchmarks**.

**What it is:** an open-source (Apache-2.0) harness that runs a real coding agent (Claude Code, Codex, Gemini/Antigravity) in a sandbox against declarative YAML tasks, then scores the files and commands it actually produced.

**Why it belongs here:** it is a benchmark/eval harness for practitioners shipping agent workflows, and it treats the harness itself as the object of measurement rather than the model. Concretely: a `skill_triggered` criterion fanned over a labelled dataset reports suite-level precision/recall/F1, so a skill that silently stops being retrieved surfaces as a failing CI gate instead of being attributed to model regression. It also carries per-tool token/cost telemetry and an A/B experiment layer that resolves task × variant combinations, so model-vs-model and harness-vs-harness runs are directly comparable.

**Quality bar:**
- Active — released to PyPI as [`coder-eval`](https://pypi.org/project/coder-eval/), currently 0.8.x
- Clearly scoped, documented at https://coder-eval.com/docs
- Non-duplicative — nearest neighbours are agent benchmarks with fixed task sets; this is a harness for evaluating your own tasks and skills

**Followed CONTRIBUTING.md:**
- Edited only `data/projects.yaml` for the entry (full schema: `name`, `repo_url`, `category`, `summary_en`, `summary_zh`, `tags`, `stars_snapshot`, `updated_at`, `license`, `why_included`)
- Regenerated `README.md` and `README_zh.md` with `scripts/render_readme.py` — sorted correctly by stars within the category
- Ran `scripts/verify_catalog.py`; report committed as `reports/verification/2026-07-28.md`

**⚠️ Two pre-existing verification failures, neither caused by this entry** — flagging so the red report isn't mistaken for my change:

1. `broken urls: 1` — `https://openreview.net/pdf?id=eONq7FdiHa` (the citation URL in `scripts/render_readme.py`) now returns **HTTP 403** to automated requests. It resolves fine in a browser; openreview.net appears to have started blocking bot user-agents.
2. `stale github entries (>12 months): 1` — `AGENT.md` (`agentmd/agent.md`), whose recorded `updated_at` is `2025-07-10`. The check compares that field against `today - 365 days`, so it crossed the line purely with the calendar between the last verification (2026-06-21) and today.

I deliberately did **not** run `scripts/sync_github_metadata.py`: it would refresh star counts for all 339 entries and bury this one-entry change in unrelated churn. Happy to run it, or to drop the verification report from this PR, if you'd rather refresh those yourself.

Disclosure: I'm a maintainer of the project. Happy to adjust the summary, tags, category, or `why_included` wording.
