### PR TITLE
Add red-team-blue-team-agent-fabric to Guardrails, Security & Governance

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A curated, implementation-first list of **agent harness engineering** resources, with GitHub projects as the primary focus.
 
-- Total entries: **338**
-- GitHub entries: **311 (92.0%)**
-- GitHub in project categories (excluding readings): **306/306 (100.0%)**
+- Total entries: **339**
+- GitHub entries: **312 (92.0%)**
+- GitHub in project categories (excluding readings): **307/307 (100.0%)**
 - Categories: **9**
 - Last verified: **2026-06-21**
 - Language: [English](./README.md) | [中文](./README_zh.md)
@@ -52,7 +52,7 @@ A curated, implementation-first list of **agent harness engineering** resources,
 | Protocols, Tool Interfaces & Agent Contracts | 41 |
 | Evaluation Harnesses & Benchmarks | 29 |
 | Observability & Reliability Operations | 20 |
-| Guardrails, Security & Governance | 26 |
+| Guardrails, Security & Governance | 27 |
 | Reference Harness Implementations | 82 |
 | Essential Readings & Ecosystem Maps | 32 |
 
@@ -328,6 +328,7 @@ Notes:
 | Sponsio | [GitHub](https://github.com/SponsioLabs/Sponsio) | [![star](https://img.shields.io/badge/star-477-f4b400?style=flat-square)](https://github.com/SponsioLabs/Sponsio) | contracts, runtime-safety, guardrails | Runtime enforcement layer that checks every agent action against deterministic contracts before execution. |
 | DashClaw | [GitHub](https://github.com/ucsandman/DashClaw) | [![star](https://img.shields.io/badge/star-276-f4b400?style=flat-square)](https://github.com/ucsandman/DashClaw) | approvals, policy, audit | Governance layer that intercepts risky agent actions, enforces policy, routes approvals, and records audit-ready decision trails. |
 | Tandem | [GitHub](https://github.com/frumu-ai/tandem) | [![star](https://img.shields.io/badge/star-108-f4b400?style=flat-square)](https://github.com/frumu-ai/tandem) | runtime-authority, approvals, audit | Governed runtime authority layer for agents with scoped execution, tool visibility, permissioned memory, approval gates, and audit trails. |
+| red-team-blue-team-agent-fabric | [GitHub](https://github.com/msaleme/red-team-blue-team-agent-fabric) | [![star](https://img.shields.io/badge/star-25-f4b400?style=flat-square)](https://github.com/msaleme/red-team-blue-team-agent-fabric) | security, red-team, testing, mcp | Adversarial test harness for agent systems — 603 executable tests across MCP, A2A, x402/L402, decision governance, benchmark integrity, human-in-the-loop, and skill supply chain, with commit-pinned OWASP Agentic v1.1 T1-T17 coverage. |
 
 <a id="reference-harness-implementations"></a>
 ### Reference Harness Implementations

--- a/README_zh.md
+++ b/README_zh.md
@@ -2,9 +2,9 @@
 
 一个面向 **Agent Harness Engineering** 的工程实践清单，优先收录可直接落地的 GitHub 项目。
 
-- 当前条目数: **338**
-- GitHub 条目: **311 (92.0%)**
-- 项目分类 GitHub 占比（不含阅读类）: **306/306 (100.0%)**
+- 当前条目数: **339**
+- GitHub 条目: **312 (92.0%)**
+- 项目分类 GitHub 占比（不含阅读类）: **307/307 (100.0%)**
 - 分类数量: **9**
 - 最近核对日期: **2026-06-21**
 - 语言: [English](./README.md) | [中文](./README_zh.md)
@@ -52,7 +52,7 @@
 | Protocols, Tool Interfaces & Agent Contracts | 41 |
 | Evaluation Harnesses & Benchmarks | 29 |
 | Observability & Reliability Operations | 20 |
-| Guardrails, Security & Governance | 26 |
+| Guardrails, Security & Governance | 27 |
 | Reference Harness Implementations | 82 |
 | Essential Readings & Ecosystem Maps | 32 |
 
@@ -328,6 +328,7 @@
 | Sponsio | [GitHub](https://github.com/SponsioLabs/Sponsio) | [![star](https://img.shields.io/badge/star-477-f4b400?style=flat-square)](https://github.com/SponsioLabs/Sponsio) | contracts, runtime-safety, guardrails | 运行时强制执行层，在代理动作执行前用确定性契约逐项检查。 |
 | DashClaw | [GitHub](https://github.com/ucsandman/DashClaw) | [![star](https://img.shields.io/badge/star-276-f4b400?style=flat-square)](https://github.com/ucsandman/DashClaw) | approvals, policy, audit | 面向代理的治理层，可拦截高风险动作、执行策略、路由审批，并记录可审计的决策轨迹。 |
 | Tandem | [GitHub](https://github.com/frumu-ai/tandem) | [![star](https://img.shields.io/badge/star-108-f4b400?style=flat-square)](https://github.com/frumu-ai/tandem) | runtime-authority, approvals, audit | 面向代理的运行时权限治理层，提供作用域执行、工具可见性、权限化记忆、审批门禁与审计轨迹。 |
+| red-team-blue-team-agent-fabric | [GitHub](https://github.com/msaleme/red-team-blue-team-agent-fabric) | [![star](https://img.shields.io/badge/star-25-f4b400?style=flat-square)](https://github.com/msaleme/red-team-blue-team-agent-fabric) | security, red-team, testing, mcp | 面向代理系统的对抗性测试 harness，覆盖 MCP、A2A、x402/L402、决策治理、基准完整性、人机协同与技能供应链共 603 项可执行测试，并与 OWASP Agentic v1.1 T1-T17 覆盖范围锁定提交版本对齐。 |
 
 <a id="reference-harness-implementations"></a>
 ### Reference Harness Implementations

--- a/data/projects.yaml
+++ b/data/projects.yaml
@@ -3180,6 +3180,23 @@ entries:
   license: NOASSERTION
   why_included: README explicitly frames Tandem as a runtime authority layer below the model, governing tools, memory, approvals,
     tenant-aware state, artifacts, and audit evidence.
+- name: red-team-blue-team-agent-fabric
+  repo_url: https://github.com/msaleme/red-team-blue-team-agent-fabric
+  category: Guardrails, Security & Governance
+  summary_en: Adversarial test harness for agent systems — 603 executable tests across MCP, A2A, x402/L402, decision governance,
+    benchmark integrity, human-in-the-loop, and skill supply chain, with commit-pinned OWASP Agentic v1.1 T1-T17 coverage.
+  summary_zh: 面向代理系统的对抗性测试 harness，覆盖 MCP、A2A、x402/L402、决策治理、基准完整性、人机协同与技能供应链共 603 项可执行测试，并与
+    OWASP Agentic v1.1 T1-T17 覆盖范围锁定提交版本对齐。
+  tags:
+  - security
+  - red-team
+  - testing
+  - mcp
+  stars_snapshot: 25
+  updated_at: '2026-08-08'
+  license: Apache-2.0
+  why_included: Validates governance/guardrail claims (this repo's own category) against real adversarial test execution rather
+    than static policy review — commit-pinned OWASP Agentic v1.1 T1-T17 coverage and an AIUC-1 crosswalk, not a self-graded checklist.
 - name: OpenClaw
   repo_url: https://github.com/openclaw/openclaw
   category: Reference Harness Implementations

--- a/reports/verification/2026-08-08.md
+++ b/reports/verification/2026-08-08.md
@@ -1,0 +1,68 @@
+# Verification Report
+
+- Generated at: `2026-08-08T15:53:16.177448+00:00`
+- Total entries: `339`
+- GitHub entries: `312` (92.0%)
+- GitHub in project categories (excluding `Essential Readings & Ecosystem Maps`): `307/307` (100.0%)
+- Categories: `9`
+- URL checks: `340` total, `339` reachable, `1` broken
+
+## Category Counts
+
+| Category | Entries |
+| --- | ---: |
+| Harness Architecture & Orchestration | 57 |
+| Context & Working-State Engineering | 24 |
+| Execution Substrates & Sandboxing | 27 |
+| Protocols, Tool Interfaces & Agent Contracts | 41 |
+| Evaluation Harnesses & Benchmarks | 29 |
+| Observability & Reliability Operations | 20 |
+| Guardrails, Security & Governance | 27 |
+| Reference Harness Implementations | 82 |
+| Essential Readings & Ecosystem Maps | 32 |
+
+## Structural Errors
+
+- stale github entries (>12 months): 1
+- broken urls: 1
+
+## Warnings
+
+- None
+
+## Broken URLs
+
+- `HTTP 403` https://openreview.net/pdf?id=eONq7FdiHa
+
+## Reachable URL Sample
+
+- `HEAD 200` https://blog.langchain.com/agent-frameworks-runtimes-and-harnesses-oh-my/
+- `HEAD 200` https://blog.langchain.com/evaluating-deep-agents-our-learnings/
+- `HEAD 200` https://blog.langchain.com/improving-deep-agents-with-harness-engineering/
+- `HEAD 200` https://blog.langchain.com/the-anatomy-of-an-agent-harness/
+- `HEAD 200` https://code.claude.com/docs/en/agent-sdk/overview
+- `HEAD 200` https://cognition.ai/blog/what-we-learned-building-cloud-agents
+- `HEAD 200` https://developers.openai.com/blog/eval-skills
+- `HEAD 200` https://github.com/1jehuang/jcode
+- `HEAD 200` https://github.com/21st-dev/1code
+- `HEAD 200` https://github.com/2FastLabs/agent-squad
+- `HEAD 200` https://github.com/AVIDS2/memorix
+- `HEAD 200` https://github.com/AgentOps-AI/agentops
+- `HEAD 200` https://github.com/Agenta-AI/agenta
+- `HEAD 200` https://github.com/Aider-AI/aider
+- `HEAD 200` https://github.com/AndyMik90/Aperant
+- `HEAD 200` https://github.com/Arize-ai/openinference
+- `HEAD 200` https://github.com/Arize-ai/phoenix
+- `HEAD 200` https://github.com/Atmosphere/atmosphere
+- `HEAD 200` https://github.com/BerriAI/litellm
+- `HEAD 200` https://github.com/BloopAI/vibe-kanban
+- `HEAD 200` https://github.com/BuilderIO/skills
+- `HEAD 200` https://github.com/Chachamaru127/claude-code-harness
+- `HEAD 200` https://github.com/Chorus-AIDLC/Chorus
+- `HEAD 200` https://github.com/ChromeDevTools/chrome-devtools-mcp
+- `HEAD 200` https://github.com/ComposioHQ/agent-orchestrator
+- `HEAD 200` https://github.com/DevAgentForge/Open-Claude-Cowork
+- `HEAD 200` https://github.com/EleutherAI/lm-evaluation-harness
+- `HEAD 200` https://github.com/EverMind-AI/EverOS
+- `HEAD 200` https://github.com/EveryInc/compound-engineering-plugin
+- `HEAD 200` https://github.com/FoundationAgents/OpenManus


### PR DESCRIPTION
## What

Adds [red-team-blue-team-agent-fabric](https://github.com/msaleme/red-team-blue-team-agent-fabric) to the **Guardrails, Security & Governance** category — an adversarial test harness for agent systems.

## Why it fits this category

The category is full of policy/governance layers (LiteLLM, Kong, Parlant, Portkey, DashClaw, Tandem) that *enforce* guardrails. This entry is the adversarial counterpart: it validates that governance/guardrail claims hold under actual test execution rather than static policy review. 603 executable tests across MCP, A2A, x402/L402, decision governance, benchmark integrity, human-in-the-loop, and skill supply chain — commit-pinned OWASP Agentic v1.1 T1-T17 coverage (13 direct, 4 partial, 0 not evidenced), AIUC-1 crosswalk (19/20 testable), NIST AI 800-2 aligned. v4.13.1, Apache-2.0, 25 stars.

## What I did

- Added one entry to `data/projects.yaml` following the exact schema of neighboring entries (name, repo_url, category, summary_en, summary_zh, tags, stars_snapshot, updated_at, license, why_included)
- Ran `scripts/render_readme.py` and `scripts/verify_catalog.py` per CONTRIBUTING.md, committed the regenerated `README.md`, `README_zh.md`, and verification report together with the data change

## Note on the verification report

`reports/verification/2026-08-08.md` shows 2 structural errors (1 stale GitHub entry >12mo, 1 broken URL — `openreview.net/pdf?id=eONq7FdiHa` returning 403). Both are pre-existing in the catalog and unrelated to this entry; my addition isn't in either failure. Left them alone to keep this PR scoped to the one addition rather than mixing in an unrelated fix.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>