### PR TITLE
Add flameox runtime evidence toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A curated, implementation-first list of **agent harness engineering** resources, with GitHub projects as the primary focus.
 
-- Total entries: **338**
-- GitHub entries: **311 (92.0%)**
-- GitHub in project categories (excluding readings): **306/306 (100.0%)**
+- Total entries: **339**
+- GitHub entries: **312 (92.0%)**
+- GitHub in project categories (excluding readings): **307/307 (100.0%)**
 - Categories: **9**
 - Last verified: **2026-06-21**
 - Language: [English](./README.md) | [中文](./README_zh.md)
@@ -51,7 +51,7 @@ A curated, implementation-first list of **agent harness engineering** resources,
 | Execution Substrates & Sandboxing | 27 |
 | Protocols, Tool Interfaces & Agent Contracts | 41 |
 | Evaluation Harnesses & Benchmarks | 29 |
-| Observability & Reliability Operations | 20 |
+| Observability & Reliability Operations | 21 |
 | Guardrails, Security & Governance | 26 |
 | Reference Harness Implementations | 82 |
 | Essential Readings & Ecosystem Maps | 32 |
@@ -296,6 +296,7 @@ Notes:
 | OpenInference | [GitHub](https://github.com/Arize-ai/openinference) | [![star](https://img.shields.io/badge/star-1044-f4b400?style=flat-square)](https://github.com/Arize-ai/openinference) | spec, instrumentation, observability | Open instrumentation specification and tooling for AI observability. |
 | Judgeval | [GitHub](https://github.com/JudgmentLabs/judgeval) | [![star](https://img.shields.io/badge/star-1038-f4b400?style=flat-square)](https://github.com/JudgmentLabs/judgeval) | tracing, agent-judges, monitoring | Agent improvement SDK with OpenTelemetry tracing, agent judges, online monitoring, replay evaluations, CLI workflows, and MCP access to traces and behaviors. |
 | Agentic Harness Engineering | [GitHub](https://github.com/china-qijizhifeng/agentic-harness-engineering) | [![star](https://img.shields.io/badge/star-603-f4b400?style=flat-square)](https://github.com/china-qijizhifeng/agentic-harness-engineering) | harness-optimization, trace-analysis, terminal-bench | Observability-driven system for evolving coding-agent harness components through evaluate, analyze, and improve loops. |
+| flameox | [GitHub](https://github.com/morluto/flameox) | [![star](https://img.shields.io/badge/star-5-f4b400?style=flat-square)](https://github.com/morluto/flameox) | profiling, mcp, runtime-evidence | Profiling and optimization toolkit for agents that captures traces, compares runs, and preserves runtime evidence. |
 
 <a id="guardrails-security-governance"></a>
 ### Guardrails, Security & Governance

--- a/README_zh.md
+++ b/README_zh.md
@@ -2,9 +2,9 @@
 
 一个面向 **Agent Harness Engineering** 的工程实践清单，优先收录可直接落地的 GitHub 项目。
 
-- 当前条目数: **338**
-- GitHub 条目: **311 (92.0%)**
-- 项目分类 GitHub 占比（不含阅读类）: **306/306 (100.0%)**
+- 当前条目数: **339**
+- GitHub 条目: **312 (92.0%)**
+- 项目分类 GitHub 占比（不含阅读类）: **307/307 (100.0%)**
 - 分类数量: **9**
 - 最近核对日期: **2026-06-21**
 - 语言: [English](./README.md) | [中文](./README_zh.md)
@@ -51,7 +51,7 @@
 | Execution Substrates & Sandboxing | 27 |
 | Protocols, Tool Interfaces & Agent Contracts | 41 |
 | Evaluation Harnesses & Benchmarks | 29 |
-| Observability & Reliability Operations | 20 |
+| Observability & Reliability Operations | 21 |
 | Guardrails, Security & Governance | 26 |
 | Reference Harness Implementations | 82 |
 | Essential Readings & Ecosystem Maps | 32 |
@@ -296,6 +296,7 @@
 | OpenInference | [GitHub](https://github.com/Arize-ai/openinference) | [![star](https://img.shields.io/badge/star-1044-f4b400?style=flat-square)](https://github.com/Arize-ai/openinference) | spec, instrumentation, observability | 面向 AI 可观测性的开放埋点规范与工具。 |
 | Judgeval | [GitHub](https://github.com/JudgmentLabs/judgeval) | [![star](https://img.shields.io/badge/star-1038-f4b400?style=flat-square)](https://github.com/JudgmentLabs/judgeval) | tracing, agent-judges, monitoring | 面向代理改进的 SDK，提供 OpenTelemetry 追踪、agent judge、在线监控、回放评测、CLI 流程与 MCP 访问轨迹/行为。 |
 | Agentic Harness Engineering | [GitHub](https://github.com/china-qijizhifeng/agentic-harness-engineering) | [![star](https://img.shields.io/badge/star-603-f4b400?style=flat-square)](https://github.com/china-qijizhifeng/agentic-harness-engineering) | harness-optimization, trace-analysis, terminal-bench | 通过评测、分析与改进闭环自动演进编码代理 harness 组件的可观测系统。 |
+| flameox | [GitHub](https://github.com/morluto/flameox) | [![star](https://img.shields.io/badge/star-5-f4b400?style=flat-square)](https://github.com/morluto/flameox) | profiling, mcp, runtime-evidence | 面向智能体的性能分析与优化工具包，可捕获追踪、比较运行并保留运行时证据。 |
 
 <a id="guardrails-security-governance"></a>
 ### Guardrails, Security & Governance

--- a/data/projects.yaml
+++ b/data/projects.yaml
@@ -2816,6 +2816,20 @@ entries:
   license: MIT
   why_included: README describes an open system that traces coding-agent rollouts, distills failures, and applies auditable
     edits to prompts, tools, middleware, skills, subagents, and memory.
+- name: flameox
+  repo_url: https://github.com/morluto/flameox
+  category: Observability & Reliability Operations
+  summary_en: Profiling and optimization toolkit for agents that captures traces, compares runs, and preserves runtime evidence.
+  summary_zh: 面向智能体的性能分析与优化工具包，可捕获追踪、比较运行并保留运行时证据。
+  tags:
+  - profiling
+  - mcp
+  - runtime-evidence
+  stars_snapshot: 5
+  updated_at: '2026-08-09'
+  license: none
+  why_included: Coordinates maintained profilers while retaining native artifacts and provenance, allowing agents to test
+    runtime-performance hypotheses against inspectable evidence.
 - name: LiteLLM
   repo_url: https://github.com/BerriAI/litellm
   category: Guardrails, Security & Governance


### PR DESCRIPTION
Adds flameox to Observability & Reliability Operations and regenerates the English and Chinese catalog mirrors.

flameox gives agents bounded CLI and MCP workflows that capture traces, preserve native artifacts, compare experiments, and ground runtime conclusions in inspectable evidence.

Disclosure: I maintain flameox.

Validation:
- `python3 scripts/render_readme.py`
- `git diff --check`
- `python3 scripts/verify_catalog.py --skip-links` remains red on one pre-existing stale GitHub entry; the same failure occurs on the unmodified base.