### PR TITLE
Add stipend to Guardrails, Security & Governance

### DIFF
--- a/data/projects.yaml
+++ b/data/projects.yaml
@@ -3180,6 +3180,22 @@ entries:
   license: NOASSERTION
   why_included: README explicitly frames Tandem as a runtime authority layer below the model, governing tools, memory, approvals,
     tenant-aware state, artifacts, and audit evidence.
+- name: stipend
+  repo_url: https://github.com/stipend-sh/stipend
+  category: Guardrails, Security & Governance
+  summary_en: Non-custodial USDC wallet for agents where per-transaction, per-day and per-counterparty caps and a destination
+    allowlist are enforced in the signing path rather than in a system prompt.
+  summary_zh: 面向 Agent 的非托管 USDC 钱包，单笔、每日与单一收款方限额及收款地址白名单在签名路径中强制执行，而非写在系统提示词里。
+  tags:
+  - guardrails
+  - payments
+  - policy-enforcement
+  stars_snapshot: 0
+  updated_at: '2026-08-12'
+  license: Apache-2.0
+  why_included: Worked implementation of pre-action authorization for an irreversible action - policy.py sits between the
+    agent decision and the signature, with one-time approvals bound to recipient/amount/expiry and a pre-check tool that
+    answers whether an action would be allowed without performing it.
 - name: OpenClaw
   repo_url: https://github.com/openclaw/openclaw
   category: Reference Harness Implementations


### PR DESCRIPTION
Data-only change: one entry appended to `data/projects.yaml` in the `Guardrails, Security & Governance` category, with every field the schema requires (`name`, `repo_url`, `category`, `summary_en`, `summary_zh`, `tags`, `stars_snapshot`, `updated_at`, `why_included`, plus `license`).

**What it is:** [stipend](https://github.com/stipend-sh/stipend) is a non-custodial USDC wallet for agents. The reason it belongs under guardrails rather than payments: per-transaction, per-day and per-counterparty caps and a destination allowlist are checks in [`stipend/policy.py`](https://github.com/stipend-sh/stipend/blob/main/stipend/policy.py) that a transaction passes on its way to being signed — a runtime authority layer below the model, in the same shape as Tandem and nono, applied to the one action an agent cannot undo. It also exposes a pre-check tool that answers "would this be allowed?" without performing anything, and one-time approvals bound to recipient, amount, expiry and a single use, so authorising one payment does not widen the limits for every future one.

**Two things I could not do, flagged rather than faked:**

1. I have not run `sync_github_metadata.py`, `render_readme.py` or `verify_catalog.py`, so `README.md`, `README_zh.md` and the verification report are **not** regenerated in this PR. This was authored against the GitHub API rather than a local clone. Happy for you to regenerate on merge, or tell me and I will follow up.
2. `stars_snapshot: 0` is accurate, not a placeholder — the repo is new (first commit 2026-08-08). Your CONTRIBUTING says no hard star threshold, but if a zero-star project is below the practical bar, closing this is fair.

Also worth stating: **the project has not been security-audited.** Apache-2.0, Python, active daily commits.
