### PR TITLE
Add DSH Dev Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A curated, implementation-first list of **agent harness engineering** resources, with GitHub projects as the primary focus.
 
-- Total entries: **350**
-- GitHub entries: **316 (90.3%)**
-- GitHub in project categories (excluding readings): **311/311 (100.0%)**
+- Total entries: **351**
+- GitHub entries: **317 (90.3%)**
+- GitHub in project categories (excluding readings): **312/312 (100.0%)**
 - Categories: **9**
 - Last verified: **2026-08-13**
 - Language: [English](./README.md) | [中文](./README_zh.md)
@@ -54,7 +54,7 @@ A curated, implementation-first list of **agent harness engineering** resources,
 | Harness Architecture & Orchestration | 59 |
 | Context & Working-State Engineering | 24 |
 | Execution Substrates & Sandboxing | 27 |
-| Protocols, Tool Interfaces & Agent Contracts | 41 |
+| Protocols, Tool Interfaces & Agent Contracts | 42 |
 | Evaluation Harnesses & Benchmarks | 29 |
 | Observability & Reliability Operations | 20 |
 | Guardrails, Security & Governance | 26 |
@@ -242,6 +242,7 @@ Notes:
 | Microsoft Learn MCP | [GitHub](https://github.com/MicrosoftDocs/mcp) | [![star](https://img.shields.io/badge/star-1832-f4b400?style=flat-square)](https://github.com/MicrosoftDocs/mcp) | mcp, docs, grounding | MCP server and CLI for grounding agents with Microsoft documentation sources. |
 | IBM MCP | [GitHub](https://github.com/IBM/mcp) | [![star](https://img.shields.io/badge/star-399-f4b400?style=flat-square)](https://github.com/IBM/mcp) | mcp, clients, tooling | IBM collection of MCP servers, clients, and developer tooling. |
 | AGENT.md | [GitHub](https://github.com/agentmd/agent.md) | [![star](https://img.shields.io/badge/star-89-f4b400?style=flat-square)](https://github.com/agentmd/agent.md) | standard, agent-file, interoperability | Standardized machine-readable file format for agentic coding tools. |
+| DSH Dev Actions | [GitHub](https://github.com/skitse/dsh-dev-actions) | [![star](https://img.shields.io/badge/star-1-f4b400?style=flat-square)](https://github.com/skitse/dsh-dev-actions) | human-in-the-loop, developer-actions, deepseek-harness | DeepSeek Harness plugin that lets the active AI turn repeated shell commands, acceptance prompts, and recurring instructions into visible, user-triggered sidebar actions. |
 
 <a id="evaluation-harnesses-benchmarks"></a>
 ### Evaluation Harnesses & Benchmarks

--- a/README_zh.md
+++ b/README_zh.md
@@ -2,9 +2,9 @@
 
 一个面向 **Agent Harness Engineering** 的工程实践清单，优先收录可直接落地的 GitHub 项目。
 
-- 当前条目数: **350**
-- GitHub 条目: **316 (90.3%)**
-- 项目分类 GitHub 占比（不含阅读类）: **311/311 (100.0%)**
+- 当前条目数: **351**
+- GitHub 条目: **317 (90.3%)**
+- 项目分类 GitHub 占比（不含阅读类）: **312/312 (100.0%)**
 - 分类数量: **9**
 - 最近核对日期: **2026-08-13**
 - 语言: [English](./README.md) | [中文](./README_zh.md)
@@ -54,7 +54,7 @@
 | Harness Architecture & Orchestration | 59 |
 | Context & Working-State Engineering | 24 |
 | Execution Substrates & Sandboxing | 27 |
-| Protocols, Tool Interfaces & Agent Contracts | 41 |
+| Protocols, Tool Interfaces & Agent Contracts | 42 |
 | Evaluation Harnesses & Benchmarks | 29 |
 | Observability & Reliability Operations | 20 |
 | Guardrails, Security & Governance | 26 |
@@ -242,6 +242,7 @@
 | Microsoft Learn MCP | [GitHub](https://github.com/MicrosoftDocs/mcp) | [![star](https://img.shields.io/badge/star-1832-f4b400?style=flat-square)](https://github.com/MicrosoftDocs/mcp) | mcp, docs, grounding | 为代理接入微软文档知识提供的 MCP server 与 CLI。 |
 | IBM MCP | [GitHub](https://github.com/IBM/mcp) | [![star](https://img.shields.io/badge/star-399-f4b400?style=flat-square)](https://github.com/IBM/mcp) | mcp, clients, tooling | IBM 提供的 MCP server、client 与开发工具集合。 |
 | AGENT.md | [GitHub](https://github.com/agentmd/agent.md) | [![star](https://img.shields.io/badge/star-89-f4b400?style=flat-square)](https://github.com/agentmd/agent.md) | standard, agent-file, interoperability | 面向代理编码工具的标准化机器可读文件格式。 |
+| DSH Dev Actions | [GitHub](https://github.com/skitse/dsh-dev-actions) | [![star](https://img.shields.io/badge/star-1-f4b400?style=flat-square)](https://github.com/skitse/dsh-dev-actions) | human-in-the-loop, developer-actions, deepseek-harness | DeepSeek Harness 插件，让当前 AI 将重复的终端命令、验收 Prompt 与习惯性指令主动沉淀为可见且由用户触发的侧栏动作。 |
 
 <a id="evaluation-harnesses-benchmarks"></a>
 ### Evaluation Harnesses & Benchmarks

--- a/data/projects.yaml
+++ b/data/projects.yaml
@@ -1594,6 +1594,21 @@ entries:
   updated_at: '2026-03-24'
   license: none
   why_included: Shows environment packaging patterns for reproducible evaluations.
+- name: DSH Dev Actions
+  repo_url: https://github.com/skitse/dsh-dev-actions
+  category: Protocols, Tool Interfaces & Agent Contracts
+  summary_en: DeepSeek Harness plugin that lets the active AI turn repeated shell commands, acceptance prompts, and recurring
+    instructions into visible, user-triggered sidebar actions.
+  summary_zh: DeepSeek Harness 插件，让当前 AI 将重复的终端命令、验收 Prompt 与习惯性指令主动沉淀为可见且由用户触发的侧栏动作。
+  tags:
+  - human-in-the-loop
+  - developer-actions
+  - deepseek-harness
+  stars_snapshot: 1
+  updated_at: '2026-08-13'
+  license: MIT
+  why_included: README and browser E2E document a concrete human-in-the-loop contract where the model maintains durable,
+    deduplicated action data while fixed host executors and explicit user clicks retain execution authority.
 - name: Anthropic Agent Skills
   repo_url: https://github.com/anthropics/skills
   category: Protocols, Tool Interfaces & Agent Contracts

--- a/reports/verification/2026-08-14.md
+++ b/reports/verification/2026-08-14.md
@@ -1,0 +1,37 @@
+# Verification Report
+
+- Generated at: `2026-08-13T20:40:06.676901+00:00`
+- Total entries: `351`
+- GitHub entries: `317` (90.3%)
+- GitHub in project categories (excluding `Essential Readings & Ecosystem Maps`): `312/312` (100.0%)
+- Categories: `9`
+- URL checks: `0` total, `0` reachable, `0` broken
+
+## Category Counts
+
+| Category | Entries |
+| --- | ---: |
+| Harness Architecture & Orchestration | 59 |
+| Context & Working-State Engineering | 24 |
+| Execution Substrates & Sandboxing | 27 |
+| Protocols, Tool Interfaces & Agent Contracts | 42 |
+| Evaluation Harnesses & Benchmarks | 29 |
+| Observability & Reliability Operations | 20 |
+| Guardrails, Security & Governance | 26 |
+| Reference Harness Implementations | 85 |
+| Essential Readings & Ecosystem Maps | 39 |
+
+## Structural Errors
+
+- stale github entries (>12 months): 1
+
+## Warnings
+
+- None
+
+## Broken URLs
+
+- None
+
+## Reachable URL Sample
+


### PR DESCRIPTION
## What

Adds [DSH Dev Actions](https://github.com/skitse/dsh-dev-actions) to **Protocols, Tool Interfaces & Agent Contracts**. The plugin gives a coding agent a small, durable action registry so it can turn repeated shell commands, acceptance prompts, and recurring instructions into visible sidebar actions while the user retains the final click.

## Why it fits

- concrete human-in-the-loop contract, not a model-only demo
- fixed host executors and explicit user-triggered execution
- documented browser E2E, Chinese-first and English docs, screenshot, public install artifact
- directly extends the DeepSeek Harness plugin ecosystem

## Validation

- `python3 scripts/render_readme.py`
- `python3 scripts/verify_catalog.py --skip-links`

The verifier generated `reports/verification/2026-08-14.md` and found no duplicate, schema, mirror, or URL errors. It exits non-zero on one pre-existing stale catalog entry (`AGENT.md`, metadata snapshot 2025-07-10), unrelated to this new entry. I also ran the full metadata sync in an isolated working copy to validate the new GitHub entry, but intentionally left its 300+ unrelated snapshot updates out of this focused PR.