### PR TITLE
Add LWC project memory CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A curated, implementation-first list of **agent harness engineering** resources, with GitHub projects as the primary focus.
 
-- Total entries: **350**
-- GitHub entries: **316 (90.3%)**
-- GitHub in project categories (excluding readings): **311/311 (100.0%)**
+- Total entries: **351**
+- GitHub entries: **317 (90.3%)**
+- GitHub in project categories (excluding readings): **312/312 (100.0%)**
 - Categories: **9**
 - Last verified: **2026-08-13**
 - Language: [English](./README.md) | [中文](./README_zh.md)
@@ -52,7 +52,7 @@ A curated, implementation-first list of **agent harness engineering** resources,
 | Category | Entries |
 | --- | ---: |
 | Harness Architecture & Orchestration | 59 |
-| Context & Working-State Engineering | 24 |
+| Context & Working-State Engineering | 25 |
 | Execution Substrates & Sandboxing | 27 |
 | Protocols, Tool Interfaces & Agent Contracts | 41 |
 | Evaluation Harnesses & Benchmarks | 29 |
@@ -162,6 +162,7 @@ Notes:
 | context-space | [GitHub](https://github.com/context-space/context-space) | [![star](https://img.shields.io/badge/star-812-f4b400?style=flat-square)](https://github.com/context-space/context-space) | context, infrastructure, mcp | Infrastructure project focused on context engineering building blocks and MCP-centric integrations. |
 | Memorix | [GitHub](https://github.com/AVIDS2/memorix) | [![star](https://img.shields.io/badge/star-629-f4b400?style=flat-square)](https://github.com/AVIDS2/memorix) | memory, mcp, cross-agent | Local-first cross-agent memory control plane with MCP support, workspace sync, sessions, and orchestration state. |
 | sd0x-dev-flow | [GitHub](https://github.com/sd0xdev/sd0x-dev-flow) | [![star](https://img.shields.io/badge/star-188-f4b400?style=flat-square)](https://github.com/sd0xdev/sd0x-dev-flow) | hooks, state-machine, claude-code | Claude Code harness layer with hook-enforced dual review, durable state-machine gates, context-compaction recovery, and fail-closed safety. |
+| LWC | [GitHub](https://github.com/JanYork/llm-wiki-cli) | [![star](https://img.shields.io/badge/star-31-f4b400?style=flat-square)](https://github.com/JanYork/llm-wiki-cli) | memory, mcp, coding-agents | Agent-driven proactive project-memory CLI with source-grounded durable knowledge, SQLite/FTS5 retrieval, optional document and code graphs, and lifecycle integration across coding-agent hosts. |
 
 <a id="execution-substrates-sandboxing"></a>
 ### Execution Substrates & Sandboxing

--- a/README_zh.md
+++ b/README_zh.md
@@ -2,9 +2,9 @@
 
 一个面向 **Agent Harness Engineering** 的工程实践清单，优先收录可直接落地的 GitHub 项目。
 
-- 当前条目数: **350**
-- GitHub 条目: **316 (90.3%)**
-- 项目分类 GitHub 占比（不含阅读类）: **311/311 (100.0%)**
+- 当前条目数: **351**
+- GitHub 条目: **317 (90.3%)**
+- 项目分类 GitHub 占比（不含阅读类）: **312/312 (100.0%)**
 - 分类数量: **9**
 - 最近核对日期: **2026-08-13**
 - 语言: [English](./README.md) | [中文](./README_zh.md)
@@ -52,7 +52,7 @@
 | 分类 | 条目数 |
 | --- | ---: |
 | Harness Architecture & Orchestration | 59 |
-| Context & Working-State Engineering | 24 |
+| Context & Working-State Engineering | 25 |
 | Execution Substrates & Sandboxing | 27 |
 | Protocols, Tool Interfaces & Agent Contracts | 41 |
 | Evaluation Harnesses & Benchmarks | 29 |
@@ -162,6 +162,7 @@
 | context-space | [GitHub](https://github.com/context-space/context-space) | [![star](https://img.shields.io/badge/star-812-f4b400?style=flat-square)](https://github.com/context-space/context-space) | context, infrastructure, mcp | 聚焦上下文工程基础设施的项目，强调 MCP 生态集成能力。 |
 | Memorix | [GitHub](https://github.com/AVIDS2/memorix) | [![star](https://img.shields.io/badge/star-629-f4b400?style=flat-square)](https://github.com/AVIDS2/memorix) | memory, mcp, cross-agent | 本地优先的跨代理记忆控制平面，支持 MCP、工作区同步、会话与编排状态。 |
 | sd0x-dev-flow | [GitHub](https://github.com/sd0xdev/sd0x-dev-flow) | [![star](https://img.shields.io/badge/star-188-f4b400?style=flat-square)](https://github.com/sd0xdev/sd0x-dev-flow) | hooks, state-machine, claude-code | Claude Code harness 层，提供钩子强制双重评审、持久状态机门禁、上下文压缩恢复与 fail-closed 安全机制。 |
+| LWC | [GitHub](https://github.com/JanYork/llm-wiki-cli) | [![star](https://img.shields.io/badge/star-31-f4b400?style=flat-square)](https://github.com/JanYork/llm-wiki-cli) | memory, mcp, coding-agents | Agent 驱动的主动项目记忆 CLI，提供可追溯来源的持久知识、SQLite/FTS5 检索、可选文档图与代码图，以及跨编码代理宿主的生命周期集成。 |
 
 <a id="execution-substrates-sandboxing"></a>
 ### Execution Substrates & Sandboxing

--- a/data/projects.yaml
+++ b/data/projects.yaml
@@ -1226,6 +1226,21 @@ entries:
   license: MIT
   why_included: README maps concrete code to harness sub-problems including state-machine gates, lifecycle interceptors, context
     recovery across compaction, tool gating, and review loops.
+- name: LWC
+  repo_url: https://github.com/JanYork/llm-wiki-cli
+  category: Context & Working-State Engineering
+  summary_en: Agent-driven proactive project-memory CLI with source-grounded durable knowledge, SQLite/FTS5 retrieval, optional
+    document and code graphs, and lifecycle integration across coding-agent hosts.
+  summary_zh: Agent 驱动的主动项目记忆 CLI，提供可追溯来源的持久知识、SQLite/FTS5 检索、可选文档图与代码图，以及跨编码代理宿主的生命周期集成。
+  tags:
+  - memory
+  - mcp
+  - coding-agents
+  stars_snapshot: 31
+  updated_at: '2026-08-14'
+  license: Apache-2.0
+  why_included: README documents proactive cross-session recall and maintenance, source provenance, atomic changesets, MCP plus
+    Skill and Hook integration, and explicit support for multiple coding-agent hosts.
 - name: Daytona
   repo_url: https://github.com/daytonaio/daytona
   category: Execution Substrates & Sandboxing

--- a/reports/verification/2026-08-14.md
+++ b/reports/verification/2026-08-14.md
@@ -1,0 +1,68 @@
+# Verification Report
+
+- Generated at: `2026-08-14T13:17:16.430441+00:00`
+- Total entries: `351`
+- GitHub entries: `317` (90.3%)
+- GitHub in project categories (excluding `Essential Readings & Ecosystem Maps`): `312/312` (100.0%)
+- Categories: `9`
+- URL checks: `352` total, `351` reachable, `1` broken
+
+## Category Counts
+
+| Category | Entries |
+| --- | ---: |
+| Harness Architecture & Orchestration | 59 |
+| Context & Working-State Engineering | 25 |
+| Execution Substrates & Sandboxing | 27 |
+| Protocols, Tool Interfaces & Agent Contracts | 41 |
+| Evaluation Harnesses & Benchmarks | 29 |
+| Observability & Reliability Operations | 20 |
+| Guardrails, Security & Governance | 26 |
+| Reference Harness Implementations | 85 |
+| Essential Readings & Ecosystem Maps | 39 |
+
+## Structural Errors
+
+- stale github entries (>12 months): 1
+- broken urls: 1
+
+## Warnings
+
+- None
+
+## Broken URLs
+
+- `HTTP 403` https://openreview.net/pdf?id=eONq7FdiHa
+
+## Reachable URL Sample
+
+- `HEAD 200` https://blog.langchain.com/agent-frameworks-runtimes-and-harnesses-oh-my/
+- `HEAD 200` https://blog.langchain.com/evaluating-deep-agents-our-learnings/
+- `HEAD 200` https://blog.langchain.com/improving-deep-agents-with-harness-engineering/
+- `HEAD 200` https://blog.langchain.com/the-anatomy-of-an-agent-harness/
+- `HEAD 200` https://cloud.google.com/blog/products/ai-machine-learning/agent-executor-googles-distributed-agent-runtime/
+- `HEAD 200` https://code.claude.com/docs/en/agent-sdk/overview
+- `HEAD 200` https://cognition.ai/blog/what-we-learned-building-cloud-agents
+- `HEAD 200` https://developers.openai.com/blog/eval-skills
+- `HEAD 200` https://github.com/1jehuang/jcode
+- `HEAD 200` https://github.com/21st-dev/1code
+- `HEAD 200` https://github.com/2FastLabs/agent-squad
+- `HEAD 200` https://github.com/AVIDS2/memorix
+- `HEAD 200` https://github.com/AgentOps-AI/agentops
+- `HEAD 200` https://github.com/Agenta-AI/agenta
+- `HEAD 200` https://github.com/Aider-AI/aider
+- `HEAD 200` https://github.com/AndyMik90/Aperant
+- `HEAD 200` https://github.com/Arize-ai/openinference
+- `HEAD 200` https://github.com/Arize-ai/phoenix
+- `HEAD 200` https://github.com/Atmosphere/atmosphere
+- `HEAD 200` https://github.com/BerriAI/litellm
+- `HEAD 200` https://github.com/BloopAI/vibe-kanban
+- `HEAD 200` https://github.com/BuilderIO/skills
+- `HEAD 200` https://github.com/Chachamaru127/claude-code-harness
+- `HEAD 200` https://github.com/Chorus-AIDLC/Chorus
+- `HEAD 200` https://github.com/ChromeDevTools/chrome-devtools-mcp
+- `HEAD 200` https://github.com/ComposioHQ/agent-orchestrator
+- `HEAD 200` https://github.com/DevAgentForge/Open-Claude-Cowork
+- `HEAD 200` https://github.com/EleutherAI/lm-evaluation-harness
+- `HEAD 200` https://github.com/EverMind-AI/EverOS
+- `HEAD 200` https://github.com/EveryInc/compound-engineering-plugin


### PR DESCRIPTION
## Summary

- add LWC to `Context & Working-State Engineering`
- regenerate the English and Chinese catalogs from `data/projects.yaml`
- include the generated verification report

LWC is an agent-driven proactive project-memory CLI for coding agents. It maintains source-grounded durable knowledge with SQLite/FTS5 retrieval, optional document and code graphs, atomic updates, and MCP/Skill/Hook lifecycle integration across supported hosts.

## Validation

- [x] `python3 scripts/render_readme.py`
- [x] schema, duplicate, mirror, category, and LWC activity checks pass
- [x] LWC repository URL returns HTTP 200
- [x] `git diff --check`

`python3 scripts/verify_catalog.py` reports two pre-existing catalog issues that reproduce on unchanged `upstream/main`:

- one stale GitHub entry: `AGENT.md` (`updated_at: 2025-07-10`)
- one external OpenReview PDF returning HTTP 403

Neither issue is introduced by the LWC entry.
