### PR TITLE
Add Sudarshan (Harness Architecture & Orchestration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A curated, implementation-first list of **agent harness engineering** resources, with GitHub projects as the primary focus.
 
-- Total entries: **350**
-- GitHub entries: **316 (90.3%)**
-- GitHub in project categories (excluding readings): **311/311 (100.0%)**
+- Total entries: **351**
+- GitHub entries: **317 (90.3%)**
+- GitHub in project categories (excluding readings): **312/312 (100.0%)**
 - Categories: **9**
 - Last verified: **2026-08-13**
 - Language: [English](./README.md) | [中文](./README_zh.md)
@@ -51,7 +51,7 @@ A curated, implementation-first list of **agent harness engineering** resources,
 
 | Category | Entries |
 | --- | ---: |
-| Harness Architecture & Orchestration | 59 |
+| Harness Architecture & Orchestration | 60 |
 | Context & Working-State Engineering | 24 |
 | Execution Substrates & Sandboxing | 27 |
 | Protocols, Tool Interfaces & Agent Contracts | 41 |
@@ -132,6 +132,7 @@ Notes:
 | Water | [GitHub](https://github.com/manthanguptaa/water) | [![star](https://img.shields.io/badge/star-334-f4b400?style=flat-square)](https://github.com/manthanguptaa/water) | python, framework, approval-gates | Python agent harness framework for orchestration, resilience, observability, guardrails, approval gates, sandboxing, and deployment. |
 | OmniCoreAgent | [GitHub](https://github.com/omnirexflora-labs/omnicoreagent) | [![star](https://img.shields.io/badge/star-246-f4b400?style=flat-square)](https://github.com/omnirexflora-labs/omnicoreagent) | python, mcp, serving | Python production harness with model loop, tools, MCP, memory, workspace files, guardrails, events, subagents, background tasks, and REST/SSE serving. |
 | hankweave | [GitHub](https://github.com/SouthBridgeAI/hankweave-runtime) | [![star](https://img.shields.io/badge/star-135-f4b400?style=flat-square)](https://github.com/SouthBridgeAI/hankweave-runtime) | long-horizon, runtime, checkpoints | Headless-first long-horizon runtime that orchestrates existing agent harnesses with sentinels, loops, checkpoints, and event journals. |
+| Sudarshan | [GitHub](https://github.com/Suraj1235/sudarshan-superharness) | [![star](https://img.shields.io/badge/star-1-f4b400?style=flat-square)](https://github.com/Suraj1235/sudarshan-superharness) | durable-state, verification, provider-neutral | Provider-neutral build harness driving one schema-validated action per turn to verification-gated completion, with immutable plans, budget ceilings, and kill-and-resume durable state. |
 
 <a id="context-working-state-engineering"></a>
 ### Context & Working-State Engineering

--- a/README_zh.md
+++ b/README_zh.md
@@ -2,9 +2,9 @@
 
 一个面向 **Agent Harness Engineering** 的工程实践清单，优先收录可直接落地的 GitHub 项目。
 
-- 当前条目数: **350**
-- GitHub 条目: **316 (90.3%)**
-- 项目分类 GitHub 占比（不含阅读类）: **311/311 (100.0%)**
+- 当前条目数: **351**
+- GitHub 条目: **317 (90.3%)**
+- 项目分类 GitHub 占比（不含阅读类）: **312/312 (100.0%)**
 - 分类数量: **9**
 - 最近核对日期: **2026-08-13**
 - 语言: [English](./README.md) | [中文](./README_zh.md)
@@ -51,7 +51,7 @@
 
 | 分类 | 条目数 |
 | --- | ---: |
-| Harness Architecture & Orchestration | 59 |
+| Harness Architecture & Orchestration | 60 |
 | Context & Working-State Engineering | 24 |
 | Execution Substrates & Sandboxing | 27 |
 | Protocols, Tool Interfaces & Agent Contracts | 41 |
@@ -132,6 +132,7 @@
 | Water | [GitHub](https://github.com/manthanguptaa/water) | [![star](https://img.shields.io/badge/star-334-f4b400?style=flat-square)](https://github.com/manthanguptaa/water) | python, framework, approval-gates | Python agent harness 框架，覆盖编排、韧性、可观测性、护栏、审批门禁、沙箱与部署。 |
 | OmniCoreAgent | [GitHub](https://github.com/omnirexflora-labs/omnicoreagent) | [![star](https://img.shields.io/badge/star-246-f4b400?style=flat-square)](https://github.com/omnirexflora-labs/omnicoreagent) | python, mcp, serving | Python 生产级 harness，包含模型循环、工具、MCP、记忆、工作区文件、护栏、事件、子代理、后台任务与 REST/SSE 服务。 |
 | hankweave | [GitHub](https://github.com/SouthBridgeAI/hankweave-runtime) | [![star](https://img.shields.io/badge/star-135-f4b400?style=flat-square)](https://github.com/SouthBridgeAI/hankweave-runtime) | long-horizon, runtime, checkpoints | 面向长任务的无界面运行时，可编排现有 agent harness，并提供 sentinels、循环、检查点与事件日志。 |
+| Sudarshan | [GitHub](https://github.com/Suraj1235/sudarshan-superharness) | [![star](https://img.shields.io/badge/star-1-f4b400?style=flat-square)](https://github.com/Suraj1235/sudarshan-superharness) | durable-state, verification, provider-neutral | 供应商中立的构建 Harness:每轮仅执行一个通过模式校验的动作,直至通过验证门禁完成;具备不可变计划、预算上限与可中断恢复的持久状态。 |
 
 <a id="context-working-state-engineering"></a>
 ### Context & Working-State Engineering

--- a/data/projects.yaml
+++ b/data/projects.yaml
@@ -884,6 +884,22 @@ entries:
   updated_at: '2026-08-10'
   license: Apache-2.0
   why_included: Strong example of a harness runtime built around repairability, rollback, and controlled long-running execution.
+- name: Sudarshan
+  repo_url: https://github.com/Suraj1235/sudarshan-superharness
+  category: Harness Architecture & Orchestration
+  summary_en: Provider-neutral build harness driving one schema-validated action per turn to verification-gated completion,
+    with immutable plans, budget ceilings, and kill-and-resume durable state.
+  summary_zh: 供应商中立的构建 Harness:每轮仅执行一个通过模式校验的动作,直至通过验证门禁完成;具备不可变计划、预算上限与可中断恢复的持久状态。
+  tags:
+  - durable-state
+  - verification
+  - provider-neutral
+  stars_snapshot: 1
+  updated_at: '2026-08-16'
+  license: MIT
+  why_included: 'Implements harness control as engine policy rather than prompts: schema-validated single actions, workspace-confined
+    tools, operator verification the model cannot remove, and atomic checkpoints that resume across processes; exercised over
+    OpenAI-compatible, Anthropic, Gemini, and command-bridge providers.'
 - name: Graphify
   repo_url: https://github.com/safishamsi/graphify
   category: Context & Working-State Engineering

--- a/reports/verification/2026-08-16.md
+++ b/reports/verification/2026-08-16.md
@@ -1,0 +1,68 @@
+# Verification Report
+
+- Generated at: `2026-08-15T22:28:21.296023+00:00`
+- Total entries: `351`
+- GitHub entries: `317` (90.3%)
+- GitHub in project categories (excluding `Essential Readings & Ecosystem Maps`): `312/312` (100.0%)
+- Categories: `9`
+- URL checks: `352` total, `351` reachable, `1` broken
+
+## Category Counts
+
+| Category | Entries |
+| --- | ---: |
+| Harness Architecture & Orchestration | 60 |
+| Context & Working-State Engineering | 24 |
+| Execution Substrates & Sandboxing | 27 |
+| Protocols, Tool Interfaces & Agent Contracts | 41 |
+| Evaluation Harnesses & Benchmarks | 29 |
+| Observability & Reliability Operations | 20 |
+| Guardrails, Security & Governance | 26 |
+| Reference Harness Implementations | 85 |
+| Essential Readings & Ecosystem Maps | 39 |
+
+## Structural Errors
+
+- stale github entries (>12 months): 1
+- broken urls: 1
+
+## Warnings
+
+- None
+
+## Broken URLs
+
+- `HTTP 403` https://openreview.net/pdf?id=eONq7FdiHa
+
+## Reachable URL Sample
+
+- `HEAD 200` https://blog.langchain.com/agent-frameworks-runtimes-and-harnesses-oh-my/
+- `HEAD 200` https://blog.langchain.com/evaluating-deep-agents-our-learnings/
+- `HEAD 200` https://blog.langchain.com/improving-deep-agents-with-harness-engineering/
+- `HEAD 200` https://blog.langchain.com/the-anatomy-of-an-agent-harness/
+- `HEAD 200` https://cloud.google.com/blog/products/ai-machine-learning/agent-executor-googles-distributed-agent-runtime/
+- `HEAD 200` https://code.claude.com/docs/en/agent-sdk/overview
+- `HEAD 200` https://cognition.ai/blog/what-we-learned-building-cloud-agents
+- `HEAD 200` https://developers.openai.com/blog/eval-skills
+- `HEAD 200` https://github.com/1jehuang/jcode
+- `HEAD 200` https://github.com/21st-dev/1code
+- `HEAD 200` https://github.com/2FastLabs/agent-squad
+- `HEAD 200` https://github.com/AVIDS2/memorix
+- `HEAD 200` https://github.com/AgentOps-AI/agentops
+- `HEAD 200` https://github.com/Agenta-AI/agenta
+- `HEAD 200` https://github.com/Aider-AI/aider
+- `HEAD 200` https://github.com/AndyMik90/Aperant
+- `HEAD 200` https://github.com/Arize-ai/openinference
+- `HEAD 200` https://github.com/Arize-ai/phoenix
+- `HEAD 200` https://github.com/Atmosphere/atmosphere
+- `HEAD 200` https://github.com/BerriAI/litellm
+- `HEAD 200` https://github.com/BloopAI/vibe-kanban
+- `HEAD 200` https://github.com/BuilderIO/skills
+- `HEAD 200` https://github.com/Chachamaru127/claude-code-harness
+- `HEAD 200` https://github.com/Chorus-AIDLC/Chorus
+- `HEAD 200` https://github.com/ChromeDevTools/chrome-devtools-mcp
+- `HEAD 200` https://github.com/ComposioHQ/agent-orchestrator
+- `HEAD 200` https://github.com/DevAgentForge/Open-Claude-Cowork
+- `HEAD 200` https://github.com/EleutherAI/lm-evaluation-harness
+- `HEAD 200` https://github.com/EverMind-AI/EverOS
+- `HEAD 200` https://github.com/EveryInc/compound-engineering-plugin


### PR DESCRIPTION
Adds [Sudarshan](https://github.com/Suraj1235/sudarshan-superharness) to **Harness Architecture & Orchestration** in `data/projects.yaml`, with all schema fields (including `summary_zh`), re-rendered `README.md`/`README_zh.md`, and the verification report.

**Scope fit:** a harness runtime — provider-neutral engine that drives an LLM (or a bridged agent CLI) through one schema-validated JSON action per turn to verification-gated completion, with immutable plans, budget ceilings, workspace-confined tools, and atomic checkpoints that resume across process kills and rate limits. Active (pushed 2026-08-16), documented, MIT, CI on Linux/macOS/Windows.

**Checklist:** link reachable · category correct · summaries concise · both README mirrors re-rendered from the catalog · `verify_catalog.py` run (report committed). Note: the two structural errors in the report (one stale entry, one 403 URL) are pre-existing and also present in the 2026-08-13 report; this PR does not touch those entries. I deliberately did not run the full `sync_github_metadata.py` refresh to keep the diff reviewable — my entry's `stars_snapshot`/`updated_at`/`license` are filled with current values.