### PR TITLE
Add DSH Plugin Store to plugin contract catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A curated, implementation-first list of **agent harness engineering** resources, with GitHub projects as the primary focus.
 
-- Total entries: **350**
-- GitHub entries: **316 (90.3%)**
-- GitHub in project categories (excluding readings): **311/311 (100.0%)**
+- Total entries: **351**
+- GitHub entries: **317 (90.3%)**
+- GitHub in project categories (excluding readings): **312/312 (100.0%)**
 - Categories: **9**
 - Last verified: **2026-08-13**
 - Language: [English](./README.md) | [中文](./README_zh.md)
@@ -54,7 +54,7 @@ A curated, implementation-first list of **agent harness engineering** resources,
 | Harness Architecture & Orchestration | 59 |
 | Context & Working-State Engineering | 24 |
 | Execution Substrates & Sandboxing | 27 |
-| Protocols, Tool Interfaces & Agent Contracts | 41 |
+| Protocols, Tool Interfaces & Agent Contracts | 42 |
 | Evaluation Harnesses & Benchmarks | 29 |
 | Observability & Reliability Operations | 20 |
 | Guardrails, Security & Governance | 26 |
@@ -242,6 +242,7 @@ Notes:
 | Microsoft Learn MCP | [GitHub](https://github.com/MicrosoftDocs/mcp) | [![star](https://img.shields.io/badge/star-1832-f4b400?style=flat-square)](https://github.com/MicrosoftDocs/mcp) | mcp, docs, grounding | MCP server and CLI for grounding agents with Microsoft documentation sources. |
 | IBM MCP | [GitHub](https://github.com/IBM/mcp) | [![star](https://img.shields.io/badge/star-399-f4b400?style=flat-square)](https://github.com/IBM/mcp) | mcp, clients, tooling | IBM collection of MCP servers, clients, and developer tooling. |
 | AGENT.md | [GitHub](https://github.com/agentmd/agent.md) | [![star](https://img.shields.io/badge/star-89-f4b400?style=flat-square)](https://github.com/agentmd/agent.md) | standard, agent-file, interoperability | Standardized machine-readable file format for agentic coding tools. |
+| DSH Plugin Store | [GitHub](https://github.com/sandbaseai/dsh-plugin-store) | [![star](https://img.shields.io/badge/star-1-f4b400?style=flat-square)](https://github.com/sandbaseai/dsh-plugin-store) | plugins, deepseek-harness, supply-chain | Native DeepSeek Harness plugin marketplace that gates local Web-profile installs on runtime verification, admits only npm package specs, and reports installed Cordis loader state. |
 
 <a id="evaluation-harnesses-benchmarks"></a>
 ### Evaluation Harnesses & Benchmarks

--- a/README_zh.md
+++ b/README_zh.md
@@ -2,9 +2,9 @@
 
 一个面向 **Agent Harness Engineering** 的工程实践清单，优先收录可直接落地的 GitHub 项目。
 
-- 当前条目数: **350**
-- GitHub 条目: **316 (90.3%)**
-- 项目分类 GitHub 占比（不含阅读类）: **311/311 (100.0%)**
+- 当前条目数: **351**
+- GitHub 条目: **317 (90.3%)**
+- 项目分类 GitHub 占比（不含阅读类）: **312/312 (100.0%)**
 - 分类数量: **9**
 - 最近核对日期: **2026-08-13**
 - 语言: [English](./README.md) | [中文](./README_zh.md)
@@ -54,7 +54,7 @@
 | Harness Architecture & Orchestration | 59 |
 | Context & Working-State Engineering | 24 |
 | Execution Substrates & Sandboxing | 27 |
-| Protocols, Tool Interfaces & Agent Contracts | 41 |
+| Protocols, Tool Interfaces & Agent Contracts | 42 |
 | Evaluation Harnesses & Benchmarks | 29 |
 | Observability & Reliability Operations | 20 |
 | Guardrails, Security & Governance | 26 |
@@ -242,6 +242,7 @@
 | Microsoft Learn MCP | [GitHub](https://github.com/MicrosoftDocs/mcp) | [![star](https://img.shields.io/badge/star-1832-f4b400?style=flat-square)](https://github.com/MicrosoftDocs/mcp) | mcp, docs, grounding | 为代理接入微软文档知识提供的 MCP server 与 CLI。 |
 | IBM MCP | [GitHub](https://github.com/IBM/mcp) | [![star](https://img.shields.io/badge/star-399-f4b400?style=flat-square)](https://github.com/IBM/mcp) | mcp, clients, tooling | IBM 提供的 MCP server、client 与开发工具集合。 |
 | AGENT.md | [GitHub](https://github.com/agentmd/agent.md) | [![star](https://img.shields.io/badge/star-89-f4b400?style=flat-square)](https://github.com/agentmd/agent.md) | standard, agent-file, interoperability | 面向代理编码工具的标准化机器可读文件格式。 |
+| DSH Plugin Store | [GitHub](https://github.com/sandbaseai/dsh-plugin-store) | [![star](https://img.shields.io/badge/star-1-f4b400?style=flat-square)](https://github.com/sandbaseai/dsh-plugin-store) | plugins, deepseek-harness, supply-chain | DeepSeek Harness 原生插件市场；本地 Web profile 安装以运行时验证为准入门槛，仅接受 npm package spec，并展示已安装的 Cordis loader 状态。 |
 
 <a id="evaluation-harnesses-benchmarks"></a>
 ### Evaluation Harnesses & Benchmarks

--- a/data/projects.yaml
+++ b/data/projects.yaml
@@ -4952,3 +4952,18 @@ entries:
   updated_at: '2025-01-01'
   license: n/a
   why_included: High-signal practitioner framing for harness-first implementation.
+- name: DSH Plugin Store
+  repo_url: https://github.com/sandbaseai/dsh-plugin-store
+  category: Protocols, Tool Interfaces & Agent Contracts
+  summary_en: Native DeepSeek Harness plugin marketplace that gates local Web-profile installs on runtime verification, admits
+    only npm package specs, and reports installed Cordis loader state.
+  summary_zh: DeepSeek Harness 原生插件市场；本地 Web profile 安装以运行时验证为准入门槛，仅接受 npm package spec，并展示已安装的 Cordis loader 状态。
+  tags:
+  - plugins
+  - deepseek-harness
+  - supply-chain
+  stars_snapshot: 1
+  updated_at: '2026-08-20'
+  license: MIT
+  why_included: Source exposes an inspectable plugin-admission boundary from verified catalog metadata through profile-layer installation
+    and installed-state inventory.

--- a/reports/verification/2026-08-20.md
+++ b/reports/verification/2026-08-20.md
@@ -1,0 +1,36 @@
+# Verification Report
+
+- Generated at: `2026-08-20T02:07:04.380909+00:00`
+- Total entries: `351`
+- GitHub entries: `317` (90.3%)
+- GitHub in project categories (excluding `Essential Readings & Ecosystem Maps`): `312/312` (100.0%)
+- Categories: `9`
+- URL checks: `0` total, `0` reachable, `0` broken
+
+## Category Counts
+
+| Category | Entries |
+| --- | ---: |
+| Harness Architecture & Orchestration | 59 |
+| Context & Working-State Engineering | 24 |
+| Execution Substrates & Sandboxing | 27 |
+| Protocols, Tool Interfaces & Agent Contracts | 42 |
+| Evaluation Harnesses & Benchmarks | 29 |
+| Observability & Reliability Operations | 20 |
+| Guardrails, Security & Governance | 26 |
+| Reference Harness Implementations | 85 |
+| Essential Readings & Ecosystem Maps | 39 |
+
+## Structural Errors
+
+- stale github entries (>12 months): 1
+
+## Warnings
+
+- None
+
+## Broken URLs
+
+- None
+
+## Reachable URL Sample


### PR DESCRIPTION
## Summary

- add DSH Plugin Store to the data-driven catalog
- regenerate the English and Chinese indexes
- include the current verification report

## Why it fits

DSH Plugin Store exposes an inspectable extension-admission boundary for DeepSeek Harness: runtime-verified catalog metadata, repository identity checks, restricted npm package specs, profile-layer installation, and installed Cordis loader inventory. That makes it a concrete fit for Protocols, Tool Interfaces & Agent Contracts rather than a generic marketplace listing.

## Verification

- python3 scripts/render_readme.py --check
- python3 scripts/verify_catalog.py --skip-links
- git diff --check

The catalog verifier still reports one pre-existing stale GitHub entry; this change introduces no new structural warning. SandbaseAI maintains the linked MIT-licensed project.