### PR TITLE
Add Concord MCP to agent protocol catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A curated, implementation-first list of **agent harness engineering** resources, with GitHub projects as the primary focus.
 
-- Total entries: **358**
-- GitHub entries: **324 (90.5%)**
-- GitHub in project categories (excluding readings): **319/319 (100.0%)**
+- Total entries: **359**
+- GitHub entries: **325 (90.5%)**
+- GitHub in project categories (excluding readings): **320/320 (100.0%)**
 - Categories: **9**
 - Last verified: **2026-08-24**
 - Language: [English](./README.md) | [中文](./README_zh.md)
@@ -54,7 +54,7 @@ A curated, implementation-first list of **agent harness engineering** resources,
 | Harness Architecture & Orchestration | 62 |
 | Context & Working-State Engineering | 27 |
 | Execution Substrates & Sandboxing | 27 |
-| Protocols, Tool Interfaces & Agent Contracts | 42 |
+| Protocols, Tool Interfaces & Agent Contracts | 43 |
 | Evaluation Harnesses & Benchmarks | 29 |
 | Observability & Reliability Operations | 20 |
 | Guardrails, Security & Governance | 26 |
@@ -248,6 +248,7 @@ Notes:
 | OpenGAP | [GitHub](https://github.com/open-gitagent/opengap) | [![star](https://img.shields.io/badge/star-2920-f4b400?style=flat-square)](https://github.com/open-gitagent/opengap) | git-native, cli, agent-contract | Reference CLI for the Git Agent Protocol, turning repository files into portable agent manifests, rules, skills, workflows, tools, memory, hooks, and compliance contracts. |
 | Microsoft Learn MCP | [GitHub](https://github.com/MicrosoftDocs/mcp) | [![star](https://img.shields.io/badge/star-1853-f4b400?style=flat-square)](https://github.com/MicrosoftDocs/mcp) | mcp, docs, grounding | MCP server and CLI for grounding agents with Microsoft documentation sources. |
 | IBM MCP | [GitHub](https://github.com/IBM/mcp) | [![star](https://img.shields.io/badge/star-401-f4b400?style=flat-square)](https://github.com/IBM/mcp) | mcp, clients, tooling | IBM collection of MCP servers, clients, and developer tooling. |
+| Concord MCP | [GitHub](https://github.com/Get-Concord-AI/concord-mcp) | [![star](https://img.shields.io/badge/star-243-f4b400?style=flat-square)](https://github.com/Get-Concord-AI/concord-mcp) | mcp, cross-harness, coordination | Cross-harness communication and shared work-state layer for coding agents, with work claims, overlap detection, durable updates, ownership transfer, and evidence-bearing handoffs through MCP. |
 | AGENT.md | [GitHub](https://github.com/agentmd/agent.md) | [![star](https://img.shields.io/badge/star-89-f4b400?style=flat-square)](https://github.com/agentmd/agent.md) | standard, agent-file, interoperability | Standardized machine-readable file format for agentic coding tools. |
 
 <a id="evaluation-harnesses-benchmarks"></a>

--- a/README_zh.md
+++ b/README_zh.md
@@ -2,9 +2,9 @@
 
 一个面向 **Agent Harness Engineering** 的工程实践清单，优先收录可直接落地的 GitHub 项目。
 
-- 当前条目数: **358**
-- GitHub 条目: **324 (90.5%)**
-- 项目分类 GitHub 占比（不含阅读类）: **319/319 (100.0%)**
+- 当前条目数: **359**
+- GitHub 条目: **325 (90.5%)**
+- 项目分类 GitHub 占比（不含阅读类）: **320/320 (100.0%)**
 - 分类数量: **9**
 - 最近核对日期: **2026-08-24**
 - 语言: [English](./README.md) | [中文](./README_zh.md)
@@ -54,7 +54,7 @@
 | Harness Architecture & Orchestration | 62 |
 | Context & Working-State Engineering | 27 |
 | Execution Substrates & Sandboxing | 27 |
-| Protocols, Tool Interfaces & Agent Contracts | 42 |
+| Protocols, Tool Interfaces & Agent Contracts | 43 |
 | Evaluation Harnesses & Benchmarks | 29 |
 | Observability & Reliability Operations | 20 |
 | Guardrails, Security & Governance | 26 |
@@ -248,6 +248,7 @@
 | OpenGAP | [GitHub](https://github.com/open-gitagent/opengap) | [![star](https://img.shields.io/badge/star-2920-f4b400?style=flat-square)](https://github.com/open-gitagent/opengap) | git-native, cli, agent-contract | Git Agent Protocol 的参考 CLI，可将仓库文件组织成可移植的代理 manifest、规则、技能、工作流、工具、记忆、钩子与合规契约。 |
 | Microsoft Learn MCP | [GitHub](https://github.com/MicrosoftDocs/mcp) | [![star](https://img.shields.io/badge/star-1853-f4b400?style=flat-square)](https://github.com/MicrosoftDocs/mcp) | mcp, docs, grounding | 为代理接入微软文档知识提供的 MCP server 与 CLI。 |
 | IBM MCP | [GitHub](https://github.com/IBM/mcp) | [![star](https://img.shields.io/badge/star-401-f4b400?style=flat-square)](https://github.com/IBM/mcp) | mcp, clients, tooling | IBM 提供的 MCP server、client 与开发工具集合。 |
+| Concord MCP | [GitHub](https://github.com/Get-Concord-AI/concord-mcp) | [![star](https://img.shields.io/badge/star-243-f4b400?style=flat-square)](https://github.com/Get-Concord-AI/concord-mcp) | mcp, cross-harness, coordination | 面向编码代理的跨 harness 通信与共享工作状态层，通过 MCP 提供任务认领、冲突检测、持久进度更新、所有权转移与证据化交接。 |
 | AGENT.md | [GitHub](https://github.com/agentmd/agent.md) | [![star](https://img.shields.io/badge/star-89-f4b400?style=flat-square)](https://github.com/agentmd/agent.md) | standard, agent-file, interoperability | 面向代理编码工具的标准化机器可读文件格式。 |
 
 <a id="evaluation-harnesses-benchmarks"></a>

--- a/data/projects.yaml
+++ b/data/projects.yaml
@@ -2273,6 +2273,21 @@ entries:
   updated_at: '2026-07-28'
   license: Apache-2.0
   why_included: Adds vendor-diverse protocol ecosystem coverage.
+- name: Concord MCP
+  repo_url: https://github.com/Get-Concord-AI/concord-mcp
+  category: Protocols, Tool Interfaces & Agent Contracts
+  summary_en: Cross-harness communication and shared work-state layer for coding agents, with work claims, overlap detection,
+    durable updates, ownership transfer, and evidence-bearing handoffs through MCP.
+  summary_zh: 面向编码代理的跨 harness 通信与共享工作状态层，通过 MCP 提供任务认领、冲突检测、持久进度更新、所有权转移与证据化交接。
+  tags:
+  - mcp
+  - cross-harness
+  - coordination
+  stars_snapshot: 243
+  updated_at: '2026-08-24'
+  license: MIT
+  why_included: README and implementation document a small, inspectable coordination protocol spanning Claude Code, Codex,
+    Gemini CLI, OpenCode, and other MCP-capable coding-agent harnesses without replacing their runtimes.
 - name: AGENT.md
   repo_url: https://github.com/agentmd/agent.md
   category: Protocols, Tool Interfaces & Agent Contracts

--- a/reports/verification/2026-08-24.md
+++ b/reports/verification/2026-08-24.md
@@ -1,11 +1,11 @@
 # Verification Report
 
-- Generated at: `2026-08-23T16:55:21.752394+00:00`
-- Total entries: `358`
-- GitHub entries: `324` (90.5%)
-- GitHub in project categories (excluding `Essential Readings & Ecosystem Maps`): `319/319` (100.0%)
+- Generated at: `2026-08-24T16:55:38.636003+00:00`
+- Total entries: `359`
+- GitHub entries: `325` (90.5%)
+- GitHub in project categories (excluding `Essential Readings & Ecosystem Maps`): `320/320` (100.0%)
 - Categories: `9`
-- URL checks: `359` total, `358` reachable, `1` broken
+- URL checks: `360` total, `359` reachable, `1` broken
 
 ## Category Counts
 
@@ -14,7 +14,7 @@
 | Harness Architecture & Orchestration | 62 |
 | Context & Working-State Engineering | 27 |
 | Execution Substrates & Sandboxing | 27 |
-| Protocols, Tool Interfaces & Agent Contracts | 42 |
+| Protocols, Tool Interfaces & Agent Contracts | 43 |
 | Evaluation Harnesses & Benchmarks | 29 |
 | Observability & Reliability Operations | 20 |
 | Guardrails, Security & Governance | 26 |


### PR DESCRIPTION
Adds Concord MCP under **Protocols, Tool Interfaces & Agent Contracts** as a cross-harness communication and shared work-state layer for coding agents.

The entry documents its work-claim, overlap detection, durable update, ownership transfer, and evidence-handoff primitives across Claude Code, Codex, Gemini CLI, OpenCode, and other MCP clients. English and Chinese catalogs are regenerated from the source data.

Validation:
- `python3 scripts/render_readme.py`
- `python3 scripts/verify_catalog.py` (catalog renders and Concord URL passes; the command retains the pre-existing stale-entry and OpenReview HTTP 403 failures)
- `git diff --check`