### PR TITLE
Add DeepSeek Harness Handbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 A curated, implementation-first list of **agent harness engineering** resources, with GitHub projects as the primary focus.
 
-- Total entries: **358**
-- GitHub entries: **324 (90.5%)**
+- Total entries: **359**
+- GitHub entries: **325 (90.5%)**
 - GitHub in project categories (excluding readings): **319/319 (100.0%)**
 - Categories: **9**
 - Last verified: **2026-08-24**
@@ -59,7 +59,7 @@ A curated, implementation-first list of **agent harness engineering** resources,
 | Observability & Reliability Operations | 20 |
 | Guardrails, Security & Governance | 26 |
 | Reference Harness Implementations | 86 |
-| Essential Readings & Ecosystem Maps | 39 |
+| Essential Readings & Ecosystem Maps | 40 |
 
 ## Catalog
 
@@ -445,6 +445,7 @@ Notes:
 | awesome-agentic-patterns | [GitHub](https://github.com/nibzard/awesome-agentic-patterns) | [![star](https://img.shields.io/badge/star-4900-f4b400?style=flat-square)](https://github.com/nibzard/awesome-agentic-patterns) | awesome-list, patterns, design | Catalog of reusable agentic design patterns and implementation motifs. |
 | awesome-mcp-servers | [GitHub](https://github.com/wong2/awesome-mcp-servers) | [![star](https://img.shields.io/badge/star-4276-f4b400?style=flat-square)](https://github.com/wong2/awesome-mcp-servers) | awesome-list, mcp, tools | Curated MCP server index for tool interoperability in agent systems. |
 | awesome-harness-engineering | [GitHub](https://github.com/walkinglabs/awesome-harness-engineering) | [![star](https://img.shields.io/badge/star-3904-f4b400?style=flat-square)](https://github.com/walkinglabs/awesome-harness-engineering) | awesome-list, curation, harness | Curated list focused on harness engineering articles, benchmarks, and implementations. |
+| DeepSeek Harness Handbook | [GitHub](https://github.com/sandbaseai/deepseek-harness-handbook) | [![star](https://img.shields.io/badge/star-71-f4b400?style=flat-square)](https://github.com/sandbaseai/deepseek-harness-handbook) | deepseek, handbook, troubleshooting | Independent, multilingual field guide for running, evaluating, and debugging DeepSeek Harness with source-backed examples, architecture maps, and operational scorecards. |
 | 12 Factor Agents | [Reference](https://www.humanlayer.dev/blog/12-factor-agents) | - | reading, operations, principles | Operations-oriented principles for building maintainable production agents. |
 | Agent Frameworks, Runtimes, and Harnesses, oh my! | [Reference](https://blog.langchain.com/agent-frameworks-runtimes-and-harnesses-oh-my/) | - | reading, langchain, architecture | Clear decomposition of framework vs runtime vs harness responsibilities. |
 | An open-source spec for Codex orchestration: Symphony. | [Reference](https://openai.com/index/open-source-codex-orchestration-symphony/) | - | reading, openai, orchestration | OpenAI's orchestration write-up on turning issue trackers into always-on control planes for coding agents. |

--- a/README_zh.md
+++ b/README_zh.md
@@ -2,8 +2,8 @@
 
 一个面向 **Agent Harness Engineering** 的工程实践清单，优先收录可直接落地的 GitHub 项目。
 
-- 当前条目数: **358**
-- GitHub 条目: **324 (90.5%)**
+- 当前条目数: **359**
+- GitHub 条目: **325 (90.5%)**
 - 项目分类 GitHub 占比（不含阅读类）: **319/319 (100.0%)**
 - 分类数量: **9**
 - 最近核对日期: **2026-08-24**
@@ -59,7 +59,7 @@
 | Observability & Reliability Operations | 20 |
 | Guardrails, Security & Governance | 26 |
 | Reference Harness Implementations | 86 |
-| Essential Readings & Ecosystem Maps | 39 |
+| Essential Readings & Ecosystem Maps | 40 |
 
 ## 项目清单
 
@@ -445,6 +445,7 @@
 | awesome-agentic-patterns | [GitHub](https://github.com/nibzard/awesome-agentic-patterns) | [![star](https://img.shields.io/badge/star-4900-f4b400?style=flat-square)](https://github.com/nibzard/awesome-agentic-patterns) | awesome-list, patterns, design | 可复用的 agentic 设计模式与实现范式目录。 |
 | awesome-mcp-servers | [GitHub](https://github.com/wong2/awesome-mcp-servers) | [![star](https://img.shields.io/badge/star-4276-f4b400?style=flat-square)](https://github.com/wong2/awesome-mcp-servers) | awesome-list, mcp, tools | MCP server 精选索引，便于代理系统进行工具互操作。 |
 | awesome-harness-engineering | [GitHub](https://github.com/walkinglabs/awesome-harness-engineering) | [![star](https://img.shields.io/badge/star-3904-f4b400?style=flat-square)](https://github.com/walkinglabs/awesome-harness-engineering) | awesome-list, curation, harness | 聚焦 harness engineering 的精选清单，覆盖文章、基准与实现。 |
+| DeepSeek Harness Handbook | [GitHub](https://github.com/sandbaseai/deepseek-harness-handbook) | [![star](https://img.shields.io/badge/star-71-f4b400?style=flat-square)](https://github.com/sandbaseai/deepseek-harness-handbook) | deepseek, handbook, troubleshooting | 独立维护的多语言 DeepSeek Harness 实战手册，提供基于源码验证的运行、评测与排障示例、架构图和运维评分卡。 |
 | 12 Factor Agents | [Reference](https://www.humanlayer.dev/blog/12-factor-agents) | - | reading, operations, principles | 面向生产代理可维护性的运维原则总结。 |
 | Agent Frameworks, Runtimes, and Harnesses, oh my! | [Reference](https://blog.langchain.com/agent-frameworks-runtimes-and-harnesses-oh-my/) | - | reading, langchain, architecture | 清晰拆解 framework、runtime 与 harness 的职责边界。 |
 | An open-source spec for Codex orchestration: Symphony. | [Reference](https://openai.com/index/open-source-codex-orchestration-symphony/) | - | reading, openai, orchestration | OpenAI 对编排层的实践拆解，介绍如何把 issue 跟踪器变成面向编码代理的常驻控制平面。 |

--- a/data/projects.yaml
+++ b/data/projects.yaml
@@ -4612,6 +4612,21 @@ entries:
   updated_at: '2026-08-19'
   license: NOASSERTION
   why_included: Directly related sibling list and high-quality seed source.
+- name: DeepSeek Harness Handbook
+  repo_url: https://github.com/sandbaseai/deepseek-harness-handbook
+  category: Essential Readings & Ecosystem Maps
+  summary_en: Independent, multilingual field guide for running, evaluating, and debugging DeepSeek Harness with source-backed
+    examples, architecture maps, and operational scorecards.
+  summary_zh: 独立维护的多语言 DeepSeek Harness 实战手册，提供基于源码验证的运行、评测与排障示例、架构图和运维评分卡。
+  tags:
+  - deepseek
+  - handbook
+  - troubleshooting
+  stars_snapshot: 71
+  updated_at: '2026-08-27'
+  license: Apache-2.0
+  why_included: Complements the official runtime entry with implementation-oriented guidance for profiles, plugins, MCP,
+    sandboxing, evaluation, and source-backed failure diagnosis.
 - name: 12 Factor Agents
   repo_url: https://www.humanlayer.dev/blog/12-factor-agents
   category: Essential Readings & Ecosystem Maps

--- a/reports/verification/2026-08-27.md
+++ b/reports/verification/2026-08-27.md
@@ -1,0 +1,37 @@
+# Verification Report
+
+- Generated at: `2026-08-27T10:39:07.128790+00:00`
+- Total entries: `359`
+- GitHub entries: `325` (90.5%)
+- GitHub in project categories (excluding `Essential Readings & Ecosystem Maps`): `319/319` (100.0%)
+- Categories: `9`
+- URL checks: `0` total, `0` reachable, `0` broken
+
+## Category Counts
+
+| Category | Entries |
+| --- | ---: |
+| Harness Architecture & Orchestration | 62 |
+| Context & Working-State Engineering | 27 |
+| Execution Substrates & Sandboxing | 27 |
+| Protocols, Tool Interfaces & Agent Contracts | 42 |
+| Evaluation Harnesses & Benchmarks | 29 |
+| Observability & Reliability Operations | 20 |
+| Guardrails, Security & Governance | 26 |
+| Reference Harness Implementations | 86 |
+| Essential Readings & Ecosystem Maps | 40 |
+
+## Structural Errors
+
+- stale github entries (>12 months): 2
+
+## Warnings
+
+- None
+
+## Broken URLs
+
+- None
+
+## Reachable URL Sample
+


### PR DESCRIPTION
## Summary

Adds the community-maintained [DeepSeek Harness Handbook](https://github.com/sandbaseai/deepseek-harness-handbook) to **Essential Readings & Ecosystem Maps**. It complements the existing official DeepSeek Harness runtime entry with source-backed operational guidance for profiles, plugins, MCP, sandboxing, evaluation, and troubleshooting.

I maintain the submitted handbook. It is independent and is not affiliated with or endorsed by DeepSeek.

## Validation

- Updated only `data/projects.yaml` for the catalog entry
- Regenerated `README.md` and `README_zh.md`
- `git diff --check` passes
- Catalog rendering succeeds
- The generated verification report has no duplicate/schema/mirror errors and no broken URL results when run with `--skip-links`; the verifier still reports two pre-existing GitHub entries older than its rolling 12-month threshold (`AGENT.md` and `claude-code-reverse`)
- Repository URL and metadata were verified through the GitHub API
