### PR TITLE
Add DeepSeek Harness Handbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 A curated, implementation-first list of **agent harness engineering** resources, with GitHub projects as the primary focus.
 
-- Total entries: **358**
-- GitHub entries: **324 (90.5%)**
+- Total entries: **359**
+- GitHub entries: **325 (90.5%)**
 - GitHub in project categories (excluding readings): **319/319 (100.0%)**
 - Categories: **9**
 - Last verified: **2026-08-24**
@@ -59,7 +59,7 @@ A curated, implementation-first list of **agent harness engineering** resources,
 | Observability & Reliability Operations | 20 |
 | Guardrails, Security & Governance | 26 |
 | Reference Harness Implementations | 86 |
-| Essential Readings & Ecosystem Maps | 39 |
+| Essential Readings & Ecosystem Maps | 40 |
 
 ## Catalog
 
@@ -445,6 +445,7 @@ Notes:
 | awesome-agentic-patterns | [GitHub](https://github.com/nibzard/awesome-agentic-patterns) | [![star](https://img.shields.io/badge/star-4900-f4b400?style=flat-square)](https://github.com/nibzard/awesome-agentic-patterns) | awesome-list, patterns, design | Catalog of reusable agentic design patterns and implementation motifs. |
 | awesome-mcp-servers | [GitHub](https://github.com/wong2/awesome-mcp-servers) | [![star](https://img.shields.io/badge/star-4276-f4b400?style=flat-square)](https://github.com/wong2/awesome-mcp-servers) | awesome-list, mcp, tools | Curated MCP server index for tool interoperability in agent systems. |
 | awesome-harness-engineering | [GitHub](https://github.com/walkinglabs/awesome-harness-engineering) | [![star](https://img.shields.io/badge/star-3904-f4b400?style=flat-square)](https://github.com/walkinglabs/awesome-harness-engineering) | awesome-list, curation, harness | Curated list focused on harness engineering articles, benchmarks, and implementations. |
+| DeepSeek Harness Handbook | [GitHub](https://github.com/sandbaseai/deepseek-harness-handbook) | [![star](https://img.shields.io/badge/star-74-f4b400?style=flat-square)](https://github.com/sandbaseai/deepseek-harness-handbook) | handbook, deepseek-harness, agent-runtime | English-canonical, multilingual field guide for operating and extending DeepSeek Harness with source-backed Agent runtime maps, plugin contracts, MCP, sandboxing, evaluation, and troubleshooting. |
 | 12 Factor Agents | [Reference](https://www.humanlayer.dev/blog/12-factor-agents) | - | reading, operations, principles | Operations-oriented principles for building maintainable production agents. |
 | Agent Frameworks, Runtimes, and Harnesses, oh my! | [Reference](https://blog.langchain.com/agent-frameworks-runtimes-and-harnesses-oh-my/) | - | reading, langchain, architecture | Clear decomposition of framework vs runtime vs harness responsibilities. |
 | An open-source spec for Codex orchestration: Symphony. | [Reference](https://openai.com/index/open-source-codex-orchestration-symphony/) | - | reading, openai, orchestration | OpenAI's orchestration write-up on turning issue trackers into always-on control planes for coding agents. |

--- a/README_zh.md
+++ b/README_zh.md
@@ -2,8 +2,8 @@
 
 一个面向 **Agent Harness Engineering** 的工程实践清单，优先收录可直接落地的 GitHub 项目。
 
-- 当前条目数: **358**
-- GitHub 条目: **324 (90.5%)**
+- 当前条目数: **359**
+- GitHub 条目: **325 (90.5%)**
 - 项目分类 GitHub 占比（不含阅读类）: **319/319 (100.0%)**
 - 分类数量: **9**
 - 最近核对日期: **2026-08-24**
@@ -59,7 +59,7 @@
 | Observability & Reliability Operations | 20 |
 | Guardrails, Security & Governance | 26 |
 | Reference Harness Implementations | 86 |
-| Essential Readings & Ecosystem Maps | 39 |
+| Essential Readings & Ecosystem Maps | 40 |
 
 ## 项目清单
 
@@ -445,6 +445,7 @@
 | awesome-agentic-patterns | [GitHub](https://github.com/nibzard/awesome-agentic-patterns) | [![star](https://img.shields.io/badge/star-4900-f4b400?style=flat-square)](https://github.com/nibzard/awesome-agentic-patterns) | awesome-list, patterns, design | 可复用的 agentic 设计模式与实现范式目录。 |
 | awesome-mcp-servers | [GitHub](https://github.com/wong2/awesome-mcp-servers) | [![star](https://img.shields.io/badge/star-4276-f4b400?style=flat-square)](https://github.com/wong2/awesome-mcp-servers) | awesome-list, mcp, tools | MCP server 精选索引，便于代理系统进行工具互操作。 |
 | awesome-harness-engineering | [GitHub](https://github.com/walkinglabs/awesome-harness-engineering) | [![star](https://img.shields.io/badge/star-3904-f4b400?style=flat-square)](https://github.com/walkinglabs/awesome-harness-engineering) | awesome-list, curation, harness | 聚焦 harness engineering 的精选清单，覆盖文章、基准与实现。 |
+| DeepSeek Harness Handbook | [GitHub](https://github.com/sandbaseai/deepseek-harness-handbook) | [![star](https://img.shields.io/badge/star-74-f4b400?style=flat-square)](https://github.com/sandbaseai/deepseek-harness-handbook) | handbook, deepseek-harness, agent-runtime | 以英文为主、面向多语言的 DeepSeek Harness 实战手册，提供有源码依据的 Agent 运行时图谱、插件契约、MCP、沙箱、评测与故障排查。 |
 | 12 Factor Agents | [Reference](https://www.humanlayer.dev/blog/12-factor-agents) | - | reading, operations, principles | 面向生产代理可维护性的运维原则总结。 |
 | Agent Frameworks, Runtimes, and Harnesses, oh my! | [Reference](https://blog.langchain.com/agent-frameworks-runtimes-and-harnesses-oh-my/) | - | reading, langchain, architecture | 清晰拆解 framework、runtime 与 harness 的职责边界。 |
 | An open-source spec for Codex orchestration: Symphony. | [Reference](https://openai.com/index/open-source-codex-orchestration-symphony/) | - | reading, openai, orchestration | OpenAI 对编排层的实践拆解，介绍如何把 issue 跟踪器变成面向编码代理的常驻控制平面。 |

--- a/data/projects.yaml
+++ b/data/projects.yaml
@@ -4612,6 +4612,19 @@ entries:
   updated_at: '2026-08-19'
   license: NOASSERTION
   why_included: Directly related sibling list and high-quality seed source.
+- name: DeepSeek Harness Handbook
+  repo_url: https://github.com/sandbaseai/deepseek-harness-handbook
+  category: Essential Readings & Ecosystem Maps
+  summary_en: English-canonical, multilingual field guide for operating and extending DeepSeek Harness with source-backed Agent runtime maps, plugin contracts, MCP, sandboxing, evaluation, and troubleshooting.
+  summary_zh: 以英文为主、面向多语言的 DeepSeek Harness 实战手册，提供有源码依据的 Agent 运行时图谱、插件契约、MCP、沙箱、评测与故障排查。
+  tags:
+  - handbook
+  - deepseek-harness
+  - agent-runtime
+  stars_snapshot: 74
+  updated_at: '2026-08-28'
+  license: MIT
+  why_included: Community-maintained handbook with 153 canonical English guides and 162 localized documents, linking each operational claim to an upstream source revision and an acceptance or recovery path.
 - name: 12 Factor Agents
   repo_url: https://www.humanlayer.dev/blog/12-factor-agents
   category: Essential Readings & Ecosystem Maps


### PR DESCRIPTION
## What
- add the community-maintained DeepSeek Harness Handbook to Essential Readings & Ecosystem Maps
- include English and Chinese summaries, tags, and a current star snapshot
- regenerate both catalog READMEs from data/projects.yaml

## Why
The handbook is an implementation-first, source-backed field guide with 153 canonical English guides and 162 localized documents covering Agent runtime boundaries, plugins, MCP, sandboxing, evaluation, and troubleshooting. It complements the existing official DeepSeek Harness implementation entry with operator-focused documentation.

## Verification
- `python3 scripts/render_readme.py`
- `python3 scripts/verify_catalog.py` (the repository currently reports its pre-existing stale/broken URL baseline)
- handbook content check: `npm run check` passes