### PR TITLE
docs: add YYLO to harness orchestration catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A curated, implementation-first list of **agent harness engineering** resources, with GitHub projects as the primary focus.
 
-- Total entries: **367**
-- GitHub entries: **333 (90.7%)**
-- GitHub in project categories (excluding readings): **328/328 (100.0%)**
+- Total entries: **368**
+- GitHub entries: **334 (90.8%)**
+- GitHub in project categories (excluding readings): **329/329 (100.0%)**
 - Categories: **9**
 - Last verified: **2026-08-31**
 - Language: [English](./README.md) | [中文](./README_zh.md)
@@ -51,7 +51,7 @@ A curated, implementation-first list of **agent harness engineering** resources,
 
 | Category | Entries |
 | --- | ---: |
-| Harness Architecture & Orchestration | 64 |
+| Harness Architecture & Orchestration | 65 |
 | Context & Working-State Engineering | 29 |
 | Execution Substrates & Sandboxing | 27 |
 | Protocols, Tool Interfaces & Agent Contracts | 42 |
@@ -137,6 +137,7 @@ Notes:
 | Water | [GitHub](https://github.com/manthanguptaa/water) | [![star](https://img.shields.io/badge/star-336-f4b400?style=flat-square)](https://github.com/manthanguptaa/water) | python, framework, approval-gates | Python agent harness framework for orchestration, resilience, observability, guardrails, approval gates, sandboxing, and deployment. |
 | OmniCoreAgent | [GitHub](https://github.com/omnirexflora-labs/omnicoreagent) | [![star](https://img.shields.io/badge/star-244-f4b400?style=flat-square)](https://github.com/omnirexflora-labs/omnicoreagent) | python, mcp, serving | Python production harness with model loop, tools, MCP, memory, workspace files, guardrails, events, subagents, background tasks, and REST/SSE serving. |
 | hankweave | [GitHub](https://github.com/SouthBridgeAI/hankweave-runtime) | [![star](https://img.shields.io/badge/star-135-f4b400?style=flat-square)](https://github.com/SouthBridgeAI/hankweave-runtime) | long-horizon, runtime, checkpoints | Headless-first long-horizon runtime that orchestrates existing agent harnesses with sentinels, loops, checkpoints, and event journals. |
+| YYLO | [GitHub](https://github.com/yylo-dev/yylo) | [![star](https://img.shields.io/badge/star-56-f4b400?style=flat-square)](https://github.com/yylo-dev/yylo) | orchestration, coding-agents, cli, workflows | Command-line orchestrator for coding agents with typed tasks, receipt-backed execution, bounded iteration loops, and merge and release-readiness gates. |
 
 <a id="context-working-state-engineering"></a>
 ### Context & Working-State Engineering

--- a/README_zh.md
+++ b/README_zh.md
@@ -2,9 +2,9 @@
 
 一个面向 **Agent Harness Engineering** 的工程实践清单，优先收录可直接落地的 GitHub 项目。
 
-- 当前条目数: **367**
-- GitHub 条目: **333 (90.7%)**
-- 项目分类 GitHub 占比（不含阅读类）: **328/328 (100.0%)**
+- 当前条目数: **368**
+- GitHub 条目: **334 (90.8%)**
+- 项目分类 GitHub 占比（不含阅读类）: **329/329 (100.0%)**
 - 分类数量: **9**
 - 最近核对日期: **2026-08-31**
 - 语言: [English](./README.md) | [中文](./README_zh.md)
@@ -51,7 +51,7 @@
 
 | 分类 | 条目数 |
 | --- | ---: |
-| Harness Architecture & Orchestration | 64 |
+| Harness Architecture & Orchestration | 65 |
 | Context & Working-State Engineering | 29 |
 | Execution Substrates & Sandboxing | 27 |
 | Protocols, Tool Interfaces & Agent Contracts | 42 |
@@ -137,6 +137,7 @@
 | Water | [GitHub](https://github.com/manthanguptaa/water) | [![star](https://img.shields.io/badge/star-336-f4b400?style=flat-square)](https://github.com/manthanguptaa/water) | python, framework, approval-gates | Python agent harness 框架，覆盖编排、韧性、可观测性、护栏、审批门禁、沙箱与部署。 |
 | OmniCoreAgent | [GitHub](https://github.com/omnirexflora-labs/omnicoreagent) | [![star](https://img.shields.io/badge/star-244-f4b400?style=flat-square)](https://github.com/omnirexflora-labs/omnicoreagent) | python, mcp, serving | Python 生产级 harness，包含模型循环、工具、MCP、记忆、工作区文件、护栏、事件、子代理、后台任务与 REST/SSE 服务。 |
 | hankweave | [GitHub](https://github.com/SouthBridgeAI/hankweave-runtime) | [![star](https://img.shields.io/badge/star-135-f4b400?style=flat-square)](https://github.com/SouthBridgeAI/hankweave-runtime) | long-horizon, runtime, checkpoints | 面向长任务的无界面运行时，可编排现有 agent harness，并提供 sentinels、循环、检查点与事件日志。 |
+| YYLO | [GitHub](https://github.com/yylo-dev/yylo) | [![star](https://img.shields.io/badge/star-56-f4b400?style=flat-square)](https://github.com/yylo-dev/yylo) | orchestration, coding-agents, cli, workflows | 面向编码代理的命令行编排器，提供类型化任务、回执式执行、有界迭代循环以及合并与发布就绪门禁。 |
 
 <a id="context-working-state-engineering"></a>
 ### Context & Working-State Engineering

--- a/data/projects.yaml
+++ b/data/projects.yaml
@@ -959,6 +959,22 @@ entries:
   updated_at: '2026-08-18'
   license: Apache-2.0
   why_included: Strong example of a harness runtime built around repairability, rollback, and controlled long-running execution.
+- name: YYLO
+  repo_url: https://github.com/yylo-dev/yylo
+  category: Harness Architecture & Orchestration
+  summary_en: Command-line orchestrator for coding agents with typed tasks, receipt-backed execution, bounded iteration loops,
+    and merge and release-readiness gates.
+  summary_zh: 面向编码代理的命令行编排器，提供类型化任务、回执式执行、有界迭代循环以及合并与发布就绪门禁。
+  tags:
+  - orchestration
+  - coding-agents
+  - cli
+  - workflows
+  stars_snapshot: 56
+  updated_at: '2026-09-03'
+  license: MIT
+  why_included: README documents orchestration of Pi, Claude Code, and Codex coding agents with typed task, validation,
+    merge, and release-readiness workflows plus receipt-backed loop execution.
 - name: Graphify
   repo_url: https://github.com/Graphify-Labs/graphify
   category: Context & Working-State Engineering

--- a/reports/verification/2026-09-03.md
+++ b/reports/verification/2026-09-03.md
@@ -1,0 +1,68 @@
+# Verification Report
+
+- Generated at: `2026-09-03T16:36:13.792622+00:00`
+- Total entries: `368`
+- GitHub entries: `334` (90.8%)
+- GitHub in project categories (excluding `Essential Readings & Ecosystem Maps`): `329/329` (100.0%)
+- Categories: `9`
+- URL checks: `369` total, `368` reachable, `1` broken
+
+## Category Counts
+
+| Category | Entries |
+| --- | ---: |
+| Harness Architecture & Orchestration | 65 |
+| Context & Working-State Engineering | 29 |
+| Execution Substrates & Sandboxing | 27 |
+| Protocols, Tool Interfaces & Agent Contracts | 42 |
+| Evaluation Harnesses & Benchmarks | 29 |
+| Observability & Reliability Operations | 21 |
+| Guardrails, Security & Governance | 27 |
+| Reference Harness Implementations | 89 |
+| Essential Readings & Ecosystem Maps | 39 |
+
+## Structural Errors
+
+- stale github entries (>12 months): 2
+- broken urls: 1
+
+## Warnings
+
+- None
+
+## Broken URLs
+
+- `HTTP 403` https://openreview.net/pdf?id=eONq7FdiHa
+
+## Reachable URL Sample
+
+- `HEAD 200` https://blog.langchain.com/agent-frameworks-runtimes-and-harnesses-oh-my/
+- `HEAD 200` https://blog.langchain.com/evaluating-deep-agents-our-learnings/
+- `HEAD 200` https://blog.langchain.com/improving-deep-agents-with-harness-engineering/
+- `HEAD 200` https://blog.langchain.com/the-anatomy-of-an-agent-harness/
+- `HEAD 200` https://cloud.google.com/blog/products/ai-machine-learning/agent-executor-googles-distributed-agent-runtime/
+- `HEAD 200` https://code.claude.com/docs/en/agent-sdk/overview
+- `HEAD 200` https://cognition.ai/blog/what-we-learned-building-cloud-agents
+- `HEAD 200` https://developers.openai.com/blog/eval-skills
+- `HEAD 200` https://github.com/1jehuang/jcode
+- `HEAD 200` https://github.com/21st-dev/1code
+- `HEAD 200` https://github.com/2FastLabs/agent-squad
+- `HEAD 200` https://github.com/AVIDS2/memorix
+- `HEAD 200` https://github.com/AgentOps-AI/agentops
+- `HEAD 200` https://github.com/Agenta-AI/agenta
+- `HEAD 200` https://github.com/Aider-AI/aider
+- `HEAD 200` https://github.com/AndyMik90/Aperant
+- `HEAD 200` https://github.com/Arize-ai/openinference
+- `HEAD 200` https://github.com/Arize-ai/phoenix
+- `HEAD 200` https://github.com/Atmosphere/atmosphere
+- `HEAD 200` https://github.com/BerriAI/litellm
+- `HEAD 200` https://github.com/BloopAI/vibe-kanban
+- `HEAD 200` https://github.com/BuilderIO/skills
+- `HEAD 200` https://github.com/Chachamaru127/claude-code-harness
+- `HEAD 200` https://github.com/Chorus-AIDLC/Chorus
+- `HEAD 200` https://github.com/ChromeDevTools/chrome-devtools-mcp
+- `HEAD 200` https://github.com/ComposioHQ/agent-orchestrator
+- `HEAD 200` https://github.com/DevAgentForge/Open-Claude-Cowork
+- `HEAD 200` https://github.com/EleutherAI/lm-evaluation-harness
+- `HEAD 200` https://github.com/EverMind-AI/EverOS
+- `HEAD 200` https://github.com/EveryInc/compound-engineering-plugin


### PR DESCRIPTION
## Summary
- Add YYLO to Harness Architecture & Orchestration.
- YYLO is a command-line orchestrator for coding agents (Pi, Claude Code, Codex) with typed tasks, receipt-backed execution, bounded iteration loops, and merge and release-readiness gates.
- Include English and Chinese summaries, tags, current GitHub metadata (56★, MIT, pushed today), and inclusion rationale.
- Regenerate both README mirrors and the verification report.

Repository: https://github.com/yylo-dev/yylo · npm: [@yylo/cli](https://www.npmjs.com/package/@yylo/cli) · MIT.

Validation:
- `python3 scripts/render_readme.py`
- `git diff --check`
- `python3 scripts/verify_catalog.py` ran; the report records the repository's existing baseline issues (2 stale GitHub entries and one unrelated HTTP 403 OpenReview URL). The new YYLO entry is reachable and structurally valid.