### PR TITLE
Add Reef to Harness Architecture & Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A curated, implementation-first list of **agent harness engineering** resources, with GitHub projects as the primary focus.
 
-- Total entries: **367**
-- GitHub entries: **333 (90.7%)**
-- GitHub in project categories (excluding readings): **328/328 (100.0%)**
+- Total entries: **368**
+- GitHub entries: **334 (90.8%)**
+- GitHub in project categories (excluding readings): **329/329 (100.0%)**
 - Categories: **9**
 - Last verified: **2026-08-31**
 - Language: [English](./README.md) | [中文](./README_zh.md)
@@ -51,7 +51,7 @@ A curated, implementation-first list of **agent harness engineering** resources,
 
 | Category | Entries |
 | --- | ---: |
-| Harness Architecture & Orchestration | 64 |
+| Harness Architecture & Orchestration | 65 |
 | Context & Working-State Engineering | 29 |
 | Execution Substrates & Sandboxing | 27 |
 | Protocols, Tool Interfaces & Agent Contracts | 42 |
@@ -134,6 +134,7 @@ Notes:
 | LiteLLM Agent Control Plane | [GitHub](https://github.com/LiteLLM-Labs/litellm-agent-control-plane) | [![star](https://img.shields.io/badge/star-1248-f4b400?style=flat-square)](https://github.com/LiteLLM-Labs/litellm-agent-control-plane) | control-plane, sessions, runtime | Agent control plane that provides one API and UI across OpenCode, Hermes, Claude Managed Agents, Cursor Agents API, DeepAgents, and OpenClaw runtimes. |
 | Chorus | [GitHub](https://github.com/Chorus-AIDLC/Chorus) | [![star](https://img.shields.io/badge/star-1151-f4b400?style=flat-square)](https://github.com/Chorus-AIDLC/Chorus) | ai-dlc, permissions, task-state | AI-human collaboration harness for session lifecycle, task state, sub-agent orchestration, observability, and recovery. |
 | Pydantic AI Harness | [GitHub](https://github.com/pydantic/pydantic-ai-harness) | [![star](https://img.shields.io/badge/star-840-f4b400?style=flat-square)](https://github.com/pydantic/pydantic-ai-harness) | capabilities, hooks, pydantic | Official Pydantic AI capability library for composing tools, lifecycle hooks, instructions, and model settings into reusable agent harnesses. |
+| Reef | [GitHub](https://github.com/Human-Agent-Society/reef) | [![star](https://img.shields.io/badge/star-345-f4b400?style=flat-square)](https://github.com/Human-Agent-Society/reef) | continual-learning, harness-evolution, serving | Continual-learning serving layer that records agent interactions, matches later feedback back to them, and promotes evaluated updates to model weights or the harness as versioned artifacts. |
 | Water | [GitHub](https://github.com/manthanguptaa/water) | [![star](https://img.shields.io/badge/star-336-f4b400?style=flat-square)](https://github.com/manthanguptaa/water) | python, framework, approval-gates | Python agent harness framework for orchestration, resilience, observability, guardrails, approval gates, sandboxing, and deployment. |
 | OmniCoreAgent | [GitHub](https://github.com/omnirexflora-labs/omnicoreagent) | [![star](https://img.shields.io/badge/star-244-f4b400?style=flat-square)](https://github.com/omnirexflora-labs/omnicoreagent) | python, mcp, serving | Python production harness with model loop, tools, MCP, memory, workspace files, guardrails, events, subagents, background tasks, and REST/SSE serving. |
 | hankweave | [GitHub](https://github.com/SouthBridgeAI/hankweave-runtime) | [![star](https://img.shields.io/badge/star-135-f4b400?style=flat-square)](https://github.com/SouthBridgeAI/hankweave-runtime) | long-horizon, runtime, checkpoints | Headless-first long-horizon runtime that orchestrates existing agent harnesses with sentinels, loops, checkpoints, and event journals. |

--- a/README_zh.md
+++ b/README_zh.md
@@ -2,9 +2,9 @@
 
 一个面向 **Agent Harness Engineering** 的工程实践清单，优先收录可直接落地的 GitHub 项目。
 
-- 当前条目数: **367**
-- GitHub 条目: **333 (90.7%)**
-- 项目分类 GitHub 占比（不含阅读类）: **328/328 (100.0%)**
+- 当前条目数: **368**
+- GitHub 条目: **334 (90.8%)**
+- 项目分类 GitHub 占比（不含阅读类）: **329/329 (100.0%)**
 - 分类数量: **9**
 - 最近核对日期: **2026-08-31**
 - 语言: [English](./README.md) | [中文](./README_zh.md)
@@ -51,7 +51,7 @@
 
 | 分类 | 条目数 |
 | --- | ---: |
-| Harness Architecture & Orchestration | 64 |
+| Harness Architecture & Orchestration | 65 |
 | Context & Working-State Engineering | 29 |
 | Execution Substrates & Sandboxing | 27 |
 | Protocols, Tool Interfaces & Agent Contracts | 42 |
@@ -134,6 +134,7 @@
 | LiteLLM Agent Control Plane | [GitHub](https://github.com/LiteLLM-Labs/litellm-agent-control-plane) | [![star](https://img.shields.io/badge/star-1248-f4b400?style=flat-square)](https://github.com/LiteLLM-Labs/litellm-agent-control-plane) | control-plane, sessions, runtime | 面向 OpenCode、Hermes、Claude Managed Agents、Cursor Agents API、DeepAgents 与 OpenClaw 等运行时的一体化代理控制平面。 |
 | Chorus | [GitHub](https://github.com/Chorus-AIDLC/Chorus) | [![star](https://img.shields.io/badge/star-1151-f4b400?style=flat-square)](https://github.com/Chorus-AIDLC/Chorus) | ai-dlc, permissions, task-state | 面向人机协作的 harness，管理会话生命周期、任务状态、子代理编排、可观测性与故障恢复。 |
 | Pydantic AI Harness | [GitHub](https://github.com/pydantic/pydantic-ai-harness) | [![star](https://img.shields.io/badge/star-840-f4b400?style=flat-square)](https://github.com/pydantic/pydantic-ai-harness) | capabilities, hooks, pydantic | Pydantic AI 官方能力库，可将工具、生命周期钩子、指令与模型设置组合为可复用的 agent harness。 |
+| Reef | [GitHub](https://github.com/Human-Agent-Society/reef) | [![star](https://img.shields.io/badge/star-345-f4b400?style=flat-square)](https://github.com/Human-Agent-Society/reef) | continual-learning, harness-evolution, serving | 持续学习服务层，记录 agent 交互并回匹后续反馈，将通过评测的模型权重或 harness 更新以带版本的产物发布。 |
 | Water | [GitHub](https://github.com/manthanguptaa/water) | [![star](https://img.shields.io/badge/star-336-f4b400?style=flat-square)](https://github.com/manthanguptaa/water) | python, framework, approval-gates | Python agent harness 框架，覆盖编排、韧性、可观测性、护栏、审批门禁、沙箱与部署。 |
 | OmniCoreAgent | [GitHub](https://github.com/omnirexflora-labs/omnicoreagent) | [![star](https://img.shields.io/badge/star-244-f4b400?style=flat-square)](https://github.com/omnirexflora-labs/omnicoreagent) | python, mcp, serving | Python 生产级 harness，包含模型循环、工具、MCP、记忆、工作区文件、护栏、事件、子代理、后台任务与 REST/SSE 服务。 |
 | hankweave | [GitHub](https://github.com/SouthBridgeAI/hankweave-runtime) | [![star](https://img.shields.io/badge/star-135-f4b400?style=flat-square)](https://github.com/SouthBridgeAI/hankweave-runtime) | long-horizon, runtime, checkpoints | 面向长任务的无界面运行时，可编排现有 agent harness，并提供 sentinels、循环、检查点与事件日志。 |

--- a/data/projects.yaml
+++ b/data/projects.yaml
@@ -5208,3 +5208,19 @@ entries:
   updated_at: '2025-01-01'
   license: n/a
   why_included: High-signal practitioner framing for harness-first implementation.
+- name: Reef
+  repo_url: https://github.com/Human-Agent-Society/reef
+  category: Harness Architecture & Orchestration
+  summary_en: Continual-learning serving layer that records agent interactions, matches later feedback back to them,
+    and promotes evaluated updates to model weights or the harness as versioned artifacts.
+  summary_zh: 持续学习服务层，记录 agent 交互并回匹后续反馈，将通过评测的模型权重或 harness 更新以带版本的产物发布。
+  tags:
+  - continual-learning
+  - harness-evolution
+  - serving
+  stars_snapshot: 345
+  updated_at: '2026-09-04'
+  license: Apache-2.0
+  why_included: Treats the harness as a versioned artifact behind an automated promotion gate rather than static
+    config, keeping the endpoint live across updates; documents the serve/observe/grow/commit loop against concrete
+    modules.

--- a/reports/verification/2026-09-04.md
+++ b/reports/verification/2026-09-04.md
@@ -1,0 +1,68 @@
+# Verification Report
+
+- Generated at: `2026-09-04T09:51:17.993471+00:00`
+- Total entries: `368`
+- GitHub entries: `334` (90.8%)
+- GitHub in project categories (excluding `Essential Readings & Ecosystem Maps`): `329/329` (100.0%)
+- Categories: `9`
+- URL checks: `369` total, `368` reachable, `1` broken
+
+## Category Counts
+
+| Category | Entries |
+| --- | ---: |
+| Harness Architecture & Orchestration | 65 |
+| Context & Working-State Engineering | 29 |
+| Execution Substrates & Sandboxing | 27 |
+| Protocols, Tool Interfaces & Agent Contracts | 42 |
+| Evaluation Harnesses & Benchmarks | 29 |
+| Observability & Reliability Operations | 21 |
+| Guardrails, Security & Governance | 27 |
+| Reference Harness Implementations | 89 |
+| Essential Readings & Ecosystem Maps | 39 |
+
+## Structural Errors
+
+- stale github entries (>12 months): 2
+- broken urls: 1
+
+## Warnings
+
+- None
+
+## Broken URLs
+
+- `HTTP 403` https://openreview.net/pdf?id=eONq7FdiHa
+
+## Reachable URL Sample
+
+- `HEAD 200` https://blog.langchain.com/agent-frameworks-runtimes-and-harnesses-oh-my/
+- `HEAD 200` https://blog.langchain.com/evaluating-deep-agents-our-learnings/
+- `HEAD 200` https://blog.langchain.com/improving-deep-agents-with-harness-engineering/
+- `HEAD 200` https://blog.langchain.com/the-anatomy-of-an-agent-harness/
+- `HEAD 200` https://cloud.google.com/blog/products/ai-machine-learning/agent-executor-googles-distributed-agent-runtime/
+- `HEAD 200` https://code.claude.com/docs/en/agent-sdk/overview
+- `HEAD 200` https://cognition.ai/blog/what-we-learned-building-cloud-agents
+- `HEAD 200` https://developers.openai.com/blog/eval-skills
+- `HEAD 200` https://github.com/1jehuang/jcode
+- `HEAD 200` https://github.com/21st-dev/1code
+- `HEAD 200` https://github.com/2FastLabs/agent-squad
+- `HEAD 200` https://github.com/AVIDS2/memorix
+- `HEAD 200` https://github.com/AgentOps-AI/agentops
+- `HEAD 200` https://github.com/Agenta-AI/agenta
+- `HEAD 200` https://github.com/Aider-AI/aider
+- `HEAD 200` https://github.com/AndyMik90/Aperant
+- `HEAD 200` https://github.com/Arize-ai/openinference
+- `HEAD 200` https://github.com/Arize-ai/phoenix
+- `HEAD 200` https://github.com/Atmosphere/atmosphere
+- `HEAD 200` https://github.com/BerriAI/litellm
+- `HEAD 200` https://github.com/BloopAI/vibe-kanban
+- `HEAD 200` https://github.com/BuilderIO/skills
+- `HEAD 200` https://github.com/Chachamaru127/claude-code-harness
+- `HEAD 200` https://github.com/Chorus-AIDLC/Chorus
+- `HEAD 200` https://github.com/ChromeDevTools/chrome-devtools-mcp
+- `HEAD 200` https://github.com/ComposioHQ/agent-orchestrator
+- `HEAD 200` https://github.com/DevAgentForge/Open-Claude-Cowork
+- `HEAD 200` https://github.com/EleutherAI/lm-evaluation-harness
+- `HEAD 200` https://github.com/EverMind-AI/EverOS
+- `HEAD 200` https://github.com/EveryInc/compound-engineering-plugin


### PR DESCRIPTION
Adds [Reef](https://github.com/Human-Agent-Society/reef) to `data/projects.yaml` under **Harness Architecture & Orchestration**, with both README mirrors re-rendered.

> **Disclosure:** I am a maintainer of Reef.

## What it is

A continual-learning serving layer. It records agent interactions at serve time, matches later feedback back to those records, produces a candidate update to either model weights or the harness (prompts, skills, configuration), and promotes the candidate only if it clears an evaluation gate — publishing accepted updates as versioned, rollback-capable artifacts while the endpoint stays live. The four-step loop maps to concrete modules (`service/`, `train/processors/`, `train/`, `train/evaluation/` + `artifact/`), so it reads as an architecture reference rather than a black box.

I put it in Harness Architecture & Orchestration because it is the control plane that orchestrates the serve → observe → update → promote cycle, not a harness you write agents against. It is non-duplicative with the existing runtime entries: those execute a harness, this one versions and gates changes to one.

## Against the quality bar

- **Active in the last 12 months** — yes; actively developed (repo first published 2026-08-31).
- **Clearly scoped** — post-deploy harness updates: what changes the harness after it ships, and what gates that change.
- **Reasonably documented** — README with install/usage, docs site, runnable recipes in `recipes/`. Apache-2.0, on PyPI as `reef-infra`.
- **Non-duplicative** — no existing entry covers evaluate-then-promote versioning over both weights and harness.

One thing stated plainly: Reef publishes no benchmark results or reproducible evaluation of its own improvement claims. `summary_en`/`summary_zh`/`why_included` describe only what the system mechanically does, with no performance claim attached.

## Scripts — what I ran, and two deliberate omissions

Ran all three per CONTRIBUTING. Two generated artifacts are **intentionally not committed**, and I'd rather explain than quietly drop them:

1. **`sync_github_metadata.py` output.** It refreshes star counts for all 368 entries, producing a 1397-line diff (706 insertions / 691 deletions) that would bury a one-entry change and conflict with your own sync commits. I ran it to confirm it passes (`Synced 334/334`, 0 errors) and took Reef's values from that run — `stars_snapshot: 345`, `license: Apache-2.0`, `updated_at: 2026-09-04` — but reverted the unrelated churn. Happy to include the full refresh if you'd prefer it in-band.

2. **`reports/verification/2026-09-04.md`.** My local IP got rate-limited by the URL checker across repeated runs: successive runs over *identical* data reported 1, then 138, then 335 broken URLs. Committing the last one would assert something false about your catalog. The first, least-throttled run gave `369 total, 368 reachable, 1 broken` — the single failure being a pre-existing `HTTP 403` on `https://openreview.net/pdf?id=eONq7FdiHa`, unrelated to this change. The two `stale github entries (>12 months)` are likewise pre-existing; I confirmed both failure categories reproduce on unmodified `main`. Please regenerate the report from CI or an unthrottled network.

`render_readme.py` ran clean and is committed. Reef sorts by stars into Harness Architecture & Orchestration in both `README.md` and `README_zh.md`, and the YAML parses with all nine required schema fields.