### PR TITLE
Add MaskShift to Reference Harness Implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A curated, implementation-first list of **agent harness engineering** resources, with GitHub projects as the primary focus.
 
-- Total entries: **367**
-- GitHub entries: **333 (90.7%)**
-- GitHub in project categories (excluding readings): **328/328 (100.0%)**
+- Total entries: **368**
+- GitHub entries: **334 (90.8%)**
+- GitHub in project categories (excluding readings): **329/329 (100.0%)**
 - Categories: **9**
 - Last verified: **2026-08-31**
 - Language: [English](./README.md) | [中文](./README_zh.md)
@@ -58,7 +58,7 @@ A curated, implementation-first list of **agent harness engineering** resources,
 | Evaluation Harnesses & Benchmarks | 29 |
 | Observability & Reliability Operations | 21 |
 | Guardrails, Security & Governance | 27 |
-| Reference Harness Implementations | 89 |
+| Reference Harness Implementations | 90 |
 | Essential Readings & Ecosystem Maps | 39 |
 
 ## Catalog
@@ -443,6 +443,7 @@ Notes:
 | Dexto | [GitHub](https://github.com/truffle-ai/dexto) | [![star](https://img.shields.io/badge/star-648-f4b400?style=flat-square)](https://github.com/truffle-ai/dexto) | coding-agent, sessions, mcp | Open agent harness for AI applications with YAML configs, stateful sessions, tool orchestration, memory, observability, permissions, and subagents. |
 | OpenClaw.NET | [GitHub](https://github.com/clawdotnet/openclaw.net) | [![star](https://img.shields.io/badge/star-487-f4b400?style=flat-square)](https://github.com/clawdotnet/openclaw.net) | dotnet, gateway, governance | NativeAOT-friendly .NET agent runtime and gateway with tools, memory, MCP, governance ledger, evidence bundles, and harness regression tests. |
 | Utah | [GitHub](https://github.com/inngest/utah) | [![star](https://img.shields.io/badge/star-135-f4b400?style=flat-square)](https://github.com/inngest/utah) | durable-execution, event-driven, multi-channel | Inngest-powered durable agent harness with a think-act-observe loop, step-level retries, singleton concurrency, cancellation, and multi-channel adapters. |
+| MaskShift | [GitHub](https://github.com/nafeeur/MaskShift) | [![star](https://img.shields.io/badge/star-1-f4b400?style=flat-square)](https://github.com/nafeeur/MaskShift) | terminal, model-agnostic, lazy-context | Maximalist, model-agnostic terminal coding harness with 148 native tools and 44 skills lazily masked into context by description, zero runtime dependencies, and a text protocol that gives tool-calling-free models the full tool surface. |
 
 <a id="essential-readings-ecosystem-maps"></a>
 ### Essential Readings & Ecosystem Maps

--- a/README_zh.md
+++ b/README_zh.md
@@ -2,9 +2,9 @@
 
 一个面向 **Agent Harness Engineering** 的工程实践清单，优先收录可直接落地的 GitHub 项目。
 
-- 当前条目数: **367**
-- GitHub 条目: **333 (90.7%)**
-- 项目分类 GitHub 占比（不含阅读类）: **328/328 (100.0%)**
+- 当前条目数: **368**
+- GitHub 条目: **334 (90.8%)**
+- 项目分类 GitHub 占比（不含阅读类）: **329/329 (100.0%)**
 - 分类数量: **9**
 - 最近核对日期: **2026-08-31**
 - 语言: [English](./README.md) | [中文](./README_zh.md)
@@ -58,7 +58,7 @@
 | Evaluation Harnesses & Benchmarks | 29 |
 | Observability & Reliability Operations | 21 |
 | Guardrails, Security & Governance | 27 |
-| Reference Harness Implementations | 89 |
+| Reference Harness Implementations | 90 |
 | Essential Readings & Ecosystem Maps | 39 |
 
 ## 项目清单
@@ -443,6 +443,7 @@
 | Dexto | [GitHub](https://github.com/truffle-ai/dexto) | [![star](https://img.shields.io/badge/star-648-f4b400?style=flat-square)](https://github.com/truffle-ai/dexto) | coding-agent, sessions, mcp | 面向 AI 应用的开放 agent harness，提供 YAML 配置、有状态会话、工具编排、记忆、可观测性、权限与子代理。 |
 | OpenClaw.NET | [GitHub](https://github.com/clawdotnet/openclaw.net) | [![star](https://img.shields.io/badge/star-487-f4b400?style=flat-square)](https://github.com/clawdotnet/openclaw.net) | dotnet, gateway, governance | NativeAOT 友好的 .NET 代理运行时与网关，提供工具、记忆、MCP、治理账本、证据包与 harness 回归测试。 |
 | Utah | [GitHub](https://github.com/inngest/utah) | [![star](https://img.shields.io/badge/star-135-f4b400?style=flat-square)](https://github.com/inngest/utah) | durable-execution, event-driven, multi-channel | 基于 Inngest 的持久代理 harness，提供思考-行动-观察循环、步骤级重试、单例并发、取消与多通道适配。 |
+| MaskShift | [GitHub](https://github.com/nafeeur/MaskShift) | [![star](https://img.shields.io/badge/star-1-f4b400?style=flat-square)](https://github.com/nafeeur/MaskShift) | terminal, model-agnostic, lazy-context | 面向终端的模型无关型编码 harness，内置 148 个原生工具与 44 个技能，按描述惰性加载进上下文，零运行时依赖，并通过文本协议为不支持工具调用的模型提供完整工具能力。 |
 
 <a id="essential-readings-ecosystem-maps"></a>
 ### Essential Readings & Ecosystem Maps

--- a/data/projects.yaml
+++ b/data/projects.yaml
@@ -3506,6 +3506,22 @@ entries:
   updated_at: '2026-08-30'
   license: Apache-2.0
   why_included: High-signal open implementation of a local coding-agent harness from a primary platform vendor.
+- name: MaskShift
+  repo_url: https://github.com/nafeeur/MaskShift
+  category: Reference Harness Implementations
+  summary_en: Maximalist, model-agnostic terminal coding harness with 148 native tools and 44 skills lazily masked into
+    context by description, zero runtime dependencies, and a text protocol that gives tool-calling-free models the full
+    tool surface.
+  summary_zh: 面向终端的模型无关型编码 harness，内置 148 个原生工具与 44 个技能，按描述惰性加载进上下文，零运行时依赖，并通过文本协议为不支持工具调用的模型提供完整工具能力。
+  tags:
+  - terminal
+  - model-agnostic
+  - lazy-context
+  stars_snapshot: 1
+  updated_at: '2026-09-06'
+  license: GPL-3.0
+  why_included: Distinct lazy-loading harness design (full tool/skill catalog held outside context, inserted only per
+    step) plus a text-based tool protocol that extends tool-use workflows to models without native function calling.
 - name: Browser Use
   repo_url: https://github.com/browser-use/browser-use
   category: Reference Harness Implementations


### PR DESCRIPTION
Maximalist, model-agnostic terminal coding harness: 148 native tools and 44 skills held outside context and lazily masked in by description per step, zero runtime dependencies (Node.js built-ins only), and a text-based tool protocol that gives models without native function calling the full tool surface.

https://github.com/nafeeur/MaskShift