### PR TITLE
Add Nausicaa harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A curated, implementation-first list of **agent harness engineering** resources, with GitHub projects as the primary focus.
 
-- Total entries: **367**
-- GitHub entries: **333 (90.7%)**
-- GitHub in project categories (excluding readings): **328/328 (100.0%)**
+- Total entries: **368**
+- GitHub entries: **334 (90.8%)**
+- GitHub in project categories (excluding readings): **329/329 (100.0%)**
 - Categories: **9**
 - Last verified: **2026-08-31**
 - Language: [English](./README.md) | [中文](./README_zh.md)
@@ -58,7 +58,7 @@ A curated, implementation-first list of **agent harness engineering** resources,
 | Evaluation Harnesses & Benchmarks | 29 |
 | Observability & Reliability Operations | 21 |
 | Guardrails, Security & Governance | 27 |
-| Reference Harness Implementations | 89 |
+| Reference Harness Implementations | 90 |
 | Essential Readings & Ecosystem Maps | 39 |
 
 ## Catalog
@@ -443,6 +443,7 @@ Notes:
 | Dexto | [GitHub](https://github.com/truffle-ai/dexto) | [![star](https://img.shields.io/badge/star-648-f4b400?style=flat-square)](https://github.com/truffle-ai/dexto) | coding-agent, sessions, mcp | Open agent harness for AI applications with YAML configs, stateful sessions, tool orchestration, memory, observability, permissions, and subagents. |
 | OpenClaw.NET | [GitHub](https://github.com/clawdotnet/openclaw.net) | [![star](https://img.shields.io/badge/star-487-f4b400?style=flat-square)](https://github.com/clawdotnet/openclaw.net) | dotnet, gateway, governance | NativeAOT-friendly .NET agent runtime and gateway with tools, memory, MCP, governance ledger, evidence bundles, and harness regression tests. |
 | Utah | [GitHub](https://github.com/inngest/utah) | [![star](https://img.shields.io/badge/star-135-f4b400?style=flat-square)](https://github.com/inngest/utah) | durable-execution, event-driven, multi-channel | Inngest-powered durable agent harness with a think-act-observe loop, step-level retries, singleton concurrency, cancellation, and multi-channel adapters. |
+| Nausicaa | [GitHub](https://github.com/jackispm/nausicaa-harness) | [![star](https://img.shields.io/badge/star-1-f4b400?style=flat-square)](https://github.com/jackispm/nausicaa-harness) | multi-agent, multi-topology, a2a, durable-runs | General-purpose TypeScript agent runtime built from addressable Lanes, an optional Teto observer lane, durable Run ledgers, daemon/worker lifecycle, and cross-Run A2A. |
 
 <a id="essential-readings-ecosystem-maps"></a>
 ### Essential Readings & Ecosystem Maps

--- a/README_zh.md
+++ b/README_zh.md
@@ -2,9 +2,9 @@
 
 一个面向 **Agent Harness Engineering** 的工程实践清单，优先收录可直接落地的 GitHub 项目。
 
-- 当前条目数: **367**
-- GitHub 条目: **333 (90.7%)**
-- 项目分类 GitHub 占比（不含阅读类）: **328/328 (100.0%)**
+- 当前条目数: **368**
+- GitHub 条目: **334 (90.8%)**
+- 项目分类 GitHub 占比（不含阅读类）: **329/329 (100.0%)**
 - 分类数量: **9**
 - 最近核对日期: **2026-08-31**
 - 语言: [English](./README.md) | [中文](./README_zh.md)
@@ -58,7 +58,7 @@
 | Evaluation Harnesses & Benchmarks | 29 |
 | Observability & Reliability Operations | 21 |
 | Guardrails, Security & Governance | 27 |
-| Reference Harness Implementations | 89 |
+| Reference Harness Implementations | 90 |
 | Essential Readings & Ecosystem Maps | 39 |
 
 ## 项目清单
@@ -443,6 +443,7 @@
 | Dexto | [GitHub](https://github.com/truffle-ai/dexto) | [![star](https://img.shields.io/badge/star-648-f4b400?style=flat-square)](https://github.com/truffle-ai/dexto) | coding-agent, sessions, mcp | 面向 AI 应用的开放 agent harness，提供 YAML 配置、有状态会话、工具编排、记忆、可观测性、权限与子代理。 |
 | OpenClaw.NET | [GitHub](https://github.com/clawdotnet/openclaw.net) | [![star](https://img.shields.io/badge/star-487-f4b400?style=flat-square)](https://github.com/clawdotnet/openclaw.net) | dotnet, gateway, governance | NativeAOT 友好的 .NET 代理运行时与网关，提供工具、记忆、MCP、治理账本、证据包与 harness 回归测试。 |
 | Utah | [GitHub](https://github.com/inngest/utah) | [![star](https://img.shields.io/badge/star-135-f4b400?style=flat-square)](https://github.com/inngest/utah) | durable-execution, event-driven, multi-channel | 基于 Inngest 的持久代理 harness，提供思考-行动-观察循环、步骤级重试、单例并发、取消与多通道适配。 |
+| Nausicaa | [GitHub](https://github.com/jackispm/nausicaa-harness) | [![star](https://img.shields.io/badge/star-1-f4b400?style=flat-square)](https://github.com/jackispm/nausicaa-harness) | multi-agent, multi-topology, a2a, durable-runs | 面向通用任务的 TypeScript Agent 运行时，由可寻址 Lane、按需 Teto 观察 Lane、Durable Run ledger、daemon/worker 生命周期与跨 Run A2A 构成。 |
 
 <a id="essential-readings-ecosystem-maps"></a>
 ### Essential Readings & Ecosystem Maps

--- a/data/projects.yaml
+++ b/data/projects.yaml
@@ -4680,6 +4680,23 @@ entries:
   license: Apache-2.0
   why_included: README expands Utah as Universally Triggered Agent Harness and documents durable LLM/tool steps, retries,
     singleton concurrency, cancellation, channels, and local worker operation.
+- name: Nausicaa
+  repo_url: https://github.com/jackispm/nausicaa-harness
+  category: Reference Harness Implementations
+  summary_en: General-purpose TypeScript agent runtime built from addressable Lanes, an optional Teto observer lane, durable
+    Run ledgers, daemon/worker lifecycle, and cross-Run A2A.
+  summary_zh: 面向通用任务的 TypeScript Agent 运行时，由可寻址 Lane、按需 Teto 观察 Lane、Durable Run ledger、daemon/worker
+    生命周期与跨 Run A2A 构成。
+  tags:
+  - multi-agent
+  - multi-topology
+  - a2a
+  - durable-runs
+  stars_snapshot: 1
+  updated_at: '2026-09-06'
+  license: MIT
+  why_included: README documents an installable npm CLI and runtime contracts for Teto observation, multi-lane topology,
+    resumable runs, daemon workers, and cross-Run A2A.
 - name: awesome-claude-code
   repo_url: https://github.com/hesreallyhim/awesome-claude-code
   category: Essential Readings & Ecosystem Maps

--- a/reports/verification/2026-09-07.md
+++ b/reports/verification/2026-09-07.md
@@ -1,0 +1,68 @@
+# Verification Report
+
+- Generated at: `2026-09-06T17:13:35.315952+00:00`
+- Total entries: `368`
+- GitHub entries: `334` (90.8%)
+- GitHub in project categories (excluding `Essential Readings & Ecosystem Maps`): `329/329` (100.0%)
+- Categories: `9`
+- URL checks: `369` total, `368` reachable, `1` broken
+
+## Category Counts
+
+| Category | Entries |
+| --- | ---: |
+| Harness Architecture & Orchestration | 64 |
+| Context & Working-State Engineering | 29 |
+| Execution Substrates & Sandboxing | 27 |
+| Protocols, Tool Interfaces & Agent Contracts | 42 |
+| Evaluation Harnesses & Benchmarks | 29 |
+| Observability & Reliability Operations | 21 |
+| Guardrails, Security & Governance | 27 |
+| Reference Harness Implementations | 90 |
+| Essential Readings & Ecosystem Maps | 39 |
+
+## Structural Errors
+
+- stale github entries (>12 months): 2
+- broken urls: 1
+
+## Warnings
+
+- None
+
+## Broken URLs
+
+- `HTTP 403` https://openreview.net/pdf?id=eONq7FdiHa
+
+## Reachable URL Sample
+
+- `HEAD 200` https://blog.langchain.com/agent-frameworks-runtimes-and-harnesses-oh-my/
+- `HEAD 200` https://blog.langchain.com/evaluating-deep-agents-our-learnings/
+- `HEAD 200` https://blog.langchain.com/improving-deep-agents-with-harness-engineering/
+- `HEAD 200` https://blog.langchain.com/the-anatomy-of-an-agent-harness/
+- `HEAD 200` https://cloud.google.com/blog/products/ai-machine-learning/agent-executor-googles-distributed-agent-runtime/
+- `HEAD 200` https://code.claude.com/docs/en/agent-sdk/overview
+- `HEAD 200` https://cognition.ai/blog/what-we-learned-building-cloud-agents
+- `HEAD 200` https://developers.openai.com/blog/eval-skills
+- `HEAD 200` https://github.com/1jehuang/jcode
+- `HEAD 200` https://github.com/21st-dev/1code
+- `HEAD 200` https://github.com/2FastLabs/agent-squad
+- `HEAD 200` https://github.com/AVIDS2/memorix
+- `HEAD 200` https://github.com/AgentOps-AI/agentops
+- `HEAD 200` https://github.com/Agenta-AI/agenta
+- `HEAD 200` https://github.com/Aider-AI/aider
+- `HEAD 200` https://github.com/AndyMik90/Aperant
+- `HEAD 200` https://github.com/Arize-ai/openinference
+- `HEAD 200` https://github.com/Arize-ai/phoenix
+- `HEAD 200` https://github.com/Atmosphere/atmosphere
+- `HEAD 200` https://github.com/BerriAI/litellm
+- `HEAD 200` https://github.com/BloopAI/vibe-kanban
+- `HEAD 200` https://github.com/BuilderIO/skills
+- `HEAD 200` https://github.com/Chachamaru127/claude-code-harness
+- `HEAD 200` https://github.com/Chorus-AIDLC/Chorus
+- `HEAD 200` https://github.com/ChromeDevTools/chrome-devtools-mcp
+- `HEAD 200` https://github.com/ComposioHQ/agent-orchestrator
+- `HEAD 200` https://github.com/DevAgentForge/Open-Claude-Cowork
+- `HEAD 200` https://github.com/EleutherAI/lm-evaluation-harness
+- `HEAD 200` https://github.com/EverMind-AI/EverOS
+- `HEAD 200` https://github.com/EveryInc/compound-engineering-plugin


### PR DESCRIPTION
## Summary\n\n- Add Nausicaa to data/projects.yaml under Reference Harness Implementations.\n- Regenerate the English and Chinese README mirrors and the verification report.\n- Record current public repository metadata and MIT license.\n\n## Validation\n\n- python3 scripts/render_readme.py\n- python3 scripts/verify_catalog.py (the repository currently reports two stale entries and one existing OpenReview 403 outside this change)\n- git diff --check